### PR TITLE
Limit consecutive clicks to the detailed page #35

### DIFF
--- a/lib/src/main/java/net/spooncast/openmocker/lib/extension/FlowExt.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/extension/FlowExt.kt
@@ -1,0 +1,15 @@
+package net.spooncast.openmocker.lib.extension
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+fun <T> Flow<T>.throttleFirst(duration: Long): Flow<T> = flow {
+    var lastEmissionTime = 0L
+    collect {
+        val currentTime = System.currentTimeMillis()
+        if (currentTime - lastEmissionTime >= duration) {
+            lastEmissionTime = currentTime
+            emit(it)
+        }
+    }
+}

--- a/lib/src/main/java/net/spooncast/openmocker/lib/extension/ModifierExt.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/extension/ModifierExt.kt
@@ -1,0 +1,35 @@
+package net.spooncast.openmocker.lib.extension
+
+import androidx.compose.foundation.clickable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+
+@Composable
+fun Modifier.singleClickable(
+    enabled: Boolean = true,
+    durationMillis: Long = 1_000L,
+    onClick: () -> Unit,
+): Modifier {
+    val onClickMediator = remember(key1 = onClick) { MutableSharedFlow<() -> Unit>() }
+    val coroutineScope = rememberCoroutineScope()
+
+    LaunchedEffect(key1 = Unit) {
+        onClickMediator
+            .throttleFirst(durationMillis)
+            .collect { it.invoke() }
+    }
+
+    return this then Modifier.clickable(
+        enabled = enabled,
+        onClick = {
+            coroutineScope.launch {
+                onClickMediator.emit(onClick)
+            }
+        }
+    )
+}

--- a/lib/src/main/java/net/spooncast/openmocker/lib/ui/list/component/ApiItemWithStatus.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/ui/list/component/ApiItemWithStatus.kt
@@ -39,6 +39,7 @@ internal fun ApiItemWithStatus(
             .fillMaxWidth()
             .combinedClickable(
                 onLongClick = onLongClick,
+                onDoubleClick = { /* Do not handle */ },
                 onClick = onClick
             )
             .padding(horizontal = 15.dp, vertical = 10.dp),


### PR DESCRIPTION
Modifier.combinedClickable을 사용할 때, onDoubleClick을 null로 설정한 상태에서 연속 클릭하는 경우, onClick이 호출됩니다. 이에 본 이슈는 Modifier.combinedClickable의 onDoubleClick을 empty block으로 설정하여 해결합니다.

* 해결 과정에서 개발한 Flow.throttleFirst와 Modifier.singleClickable은 추후 사용 가능성이 있어 유지합니다.