### PR TITLE
[Phase 1.1] Core 인터페이스 정의 - MockerEngine 및 HTTP 추상화 계층

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,9 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
+    alias(libs.plugins.jetbrains.kotlin.jvm) apply false
     alias(libs.plugins.jetbrains.kotlin.kapt) apply false
+    alias(libs.plugins.jetbrains.kotlin.serialization) apply false
     alias(libs.plugins.jetbrains.kotlin.compose) apply false
     alias(libs.plugins.jetbrains.kotlin.parcelize) apply false
     alias(libs.plugins.google.dagger.hilt.android) apply false

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    alias(libs.plugins.jetbrains.kotlin.jvm)
+    alias(libs.plugins.jetbrains.kotlin.serialization)
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
+dependencies {
+    implementation(libs.jetbrains.kotlinx.serialization.json)
+
+    testImplementation(libs.junit)
+}

--- a/core/src/main/kotlin/net/spooncast/openmocker/core/HttpInterfaces.kt
+++ b/core/src/main/kotlin/net/spooncast/openmocker/core/HttpInterfaces.kt
@@ -1,0 +1,39 @@
+package net.spooncast.openmocker.core
+
+/**
+ * Platform-independent abstraction for HTTP requests.
+ *
+ * This interface provides a unified view of HTTP requests across different
+ * HTTP client implementations (OkHttp, Ktor, etc.).
+ */
+interface HttpRequest {
+    /**
+     * HTTP method (GET, POST, PUT, DELETE, etc.)
+     */
+    val method: String
+
+    /**
+     * URL path without query parameters or fragment.
+     * Should be the encoded path from the URL.
+     */
+    val path: String
+}
+
+/**
+ * Platform-independent abstraction for HTTP responses.
+ *
+ * This interface provides a unified view of HTTP responses across different
+ * HTTP client implementations (OkHttp, Ktor, etc.).
+ */
+interface HttpResponse {
+    /**
+     * HTTP status code (200, 404, 500, etc.)
+     */
+    val code: Int
+
+    /**
+     * Response body as string.
+     * For binary content, this should be the string representation.
+     */
+    val body: String
+}

--- a/core/src/main/kotlin/net/spooncast/openmocker/core/MockModels.kt
+++ b/core/src/main/kotlin/net/spooncast/openmocker/core/MockModels.kt
@@ -1,0 +1,35 @@
+package net.spooncast.openmocker.core
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Unique identifier for HTTP requests used in mocking.
+ *
+ * This class represents the key components that uniquely identify
+ * an HTTP request for mocking purposes.
+ *
+ * @property method HTTP method (GET, POST, PUT, DELETE, etc.)
+ * @property path URL path without query parameters or fragment
+ */
+@Serializable
+data class MockKey(
+    val method: String,
+    val path: String
+)
+
+/**
+ * Mock response configuration for HTTP requests.
+ *
+ * This class defines the mock response that should be returned
+ * when a matching HTTP request is intercepted.
+ *
+ * @property code HTTP status code to return (200, 404, 500, etc.)
+ * @property body Response body content as string
+ * @property delay Artificial delay in milliseconds before returning response (default: 0)
+ */
+@Serializable
+data class MockResponse(
+    val code: Int,
+    val body: String,
+    val delay: Long = 0L
+)

--- a/core/src/main/kotlin/net/spooncast/openmocker/core/MockerEngine.kt
+++ b/core/src/main/kotlin/net/spooncast/openmocker/core/MockerEngine.kt
@@ -1,0 +1,48 @@
+package net.spooncast.openmocker.core
+
+/**
+ * Core interface for HTTP mocking engine that abstracts platform-specific HTTP clients.
+ *
+ * This interface provides a unified API for mocking HTTP requests and responses,
+ * supporting both OkHttp and Ktor implementations.
+ *
+ * All methods are suspend functions to support asynchronous operations.
+ */
+interface MockerEngine {
+
+    /**
+     * Checks if a mock response should be returned for the given request.
+     *
+     * @param method HTTP method (GET, POST, etc.)
+     * @param path URL path without query parameters
+     * @return MockResponse if a mock is configured, null otherwise
+     */
+    suspend fun shouldMock(method: String, path: String): MockResponse?
+
+    /**
+     * Caches an actual HTTP response for potential mocking later.
+     *
+     * @param method HTTP method
+     * @param path URL path
+     * @param code HTTP status code
+     * @param body Response body as string
+     */
+    suspend fun cacheResponse(method: String, path: String, code: Int, body: String)
+
+    /**
+     * Enables mocking for the specified request with the given response.
+     *
+     * @param key MockKey identifying the request
+     * @param response MockResponse to return for matching requests
+     * @return true if mock was successfully enabled, false otherwise
+     */
+    suspend fun mock(key: MockKey, response: MockResponse): Boolean
+
+    /**
+     * Disables mocking for the specified request.
+     *
+     * @param key MockKey identifying the request to unmock
+     * @return true if mock was successfully disabled, false otherwise
+     */
+    suspend fun unmock(key: MockKey): Boolean
+}

--- a/core/src/main/kotlin/net/spooncast/openmocker/core/package-info.kt
+++ b/core/src/main/kotlin/net/spooncast/openmocker/core/package-info.kt
@@ -1,0 +1,43 @@
+/**
+ * OpenMocker Core - Platform-independent HTTP mocking abstractions.
+ *
+ * This package contains the core interfaces and data models that provide
+ * platform-independent abstractions for HTTP request mocking. It serves as
+ * the foundation for specific HTTP client implementations (OkHttp, Ktor, etc.).
+ *
+ * ## Key Components
+ *
+ * ### [MockerEngine]
+ * The main interface that defines the contract for HTTP mocking engines.
+ * Implementations of this interface handle the platform-specific details
+ * of intercepting HTTP requests and serving mock responses.
+ *
+ * ### [HttpRequest] and [HttpResponse]
+ * Platform-independent abstractions for HTTP requests and responses.
+ * These interfaces allow the core mocking logic to work with different
+ * HTTP client libraries without tight coupling.
+ *
+ * ### [MockKey] and [MockResponse]
+ * Data models that represent the key-value pairs used in mocking.
+ * - [MockKey]: Identifies a unique HTTP request (method + path)
+ * - [MockResponse]: Defines the mock response (code + body + delay)
+ *
+ * ## Usage Pattern
+ *
+ * 1. **Create a platform-specific implementation** of [MockerEngine]
+ * 2. **Integrate with HTTP client** by intercepting requests
+ * 3. **Check for mocks** using [MockerEngine.shouldMock]
+ * 4. **Cache responses** using [MockerEngine.cacheResponse]
+ * 5. **Control mocking** using [MockerEngine.mock] and [MockerEngine.unmock]
+ *
+ * ## Design Principles
+ *
+ * - **Platform Independence**: No dependencies on Android or specific HTTP libraries
+ * - **Async Support**: All methods are suspend functions for coroutine compatibility
+ * - **Extensibility**: Interfaces designed for easy extension and customization
+ * - **Type Safety**: Strong typing with serializable data classes
+ *
+ * @since 1.0.0
+ * @author OpenMocker Team
+ */
+package net.spooncast.openmocker.core

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,7 @@ gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 jetbrains-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 jetbrains-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 jetbrains-kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,3 +22,4 @@ dependencyResolutionManagement {
 rootProject.name = "OpenMocker"
 include(":app")
 include(":lib")
+include(":core")


### PR DESCRIPTION
## 📋 구현 개요
Phase 1.1 이슈 #64를 구현하여 OpenMocker의 플랫폼 독립적인 Core 추상화 계층을 생성했습니다.

## 🔧 구현 내용

### 1. Core 모듈 구성
- **새로운 `:core` 모듈** 추가 (순수 JVM Kotlin 모듈)
- `settings.gradle.kts`에 core 모듈 포함
- `build.gradle.kts`에 kotlin-jvm 플러그인 지원 추가
- 최신 Kotlin 2.2.10 compilerOptions DSL 사용

### 2. 핵심 인터페이스 구현

#### MockerEngine 인터페이스
```kotlin
interface MockerEngine {
    suspend fun shouldMock(method: String, path: String): MockResponse?
    suspend fun cacheResponse(method: String, path: String, code: Int, body: String)
    suspend fun mock(key: MockKey, response: MockResponse): Boolean
    suspend fun unmock(key: MockKey): Boolean
}
```

#### HTTP 추상화 인터페이스
```kotlin
interface HttpRequest {
    val method: String
    val path: String
}

interface HttpResponse {
    val code: Int
    val body: String
}
```

### 3. 데이터 모델 정의
- **MockKey**: HTTP 요청 식별자 (method + path)
- **MockResponse**: 모킹 응답 설정 (code + body + delay)
- Kotlinx Serialization 지원으로 직렬화 가능

### 4. 패키지 문서화
- 상세한 KDoc 주석과 사용법 가이드
- 설계 원칙과 사용 패턴 명시
- 플랫폼 독립성과 확장성 강조

## ✅ 달성한 완료 조건
- [x] MockerEngine 인터페이스 정의 완료
- [x] HttpRequest/HttpResponse 인터페이스 정의 완료
- [x] MockKey/MockResponse 데이터 클래스 정의 완료
- [x] Core 모듈 빌드 성공 검증
- [x] 패키지 구조 문서화 완료
- [x] 플랫폼 독립성 및 코루틴 지원 보장

## 🏗️ 기술적 특징

### 플랫폼 독립성
- Android/JVM 특정 클래스 의존성 제거
- 순수 Kotlin JVM 모듈로 구현
- 향후 다른 HTTP 클라이언트 지원 용이

### 비동기 지원
- 모든 메서드를 suspend 함수로 정의
- 코루틴 호환성 보장
- 네이티브 비동기 처리 지원

### 확장 가능한 설계
- 인터페이스 기반 설계로 유연성 제공
- 기존 OpenMocker 컨벤션 유지
- 향후 Ktor 플러그인 구현의 기반 마련

## 🔗 후속 작업
이 작업으로 다음 Phase들을 위한 견고한 기반이 마련되었습니다:
- **Phase 1.2**: Core 데이터 모델 정의
- **Phase 1.3**: Core 저장소 추상화  
- **Phase 2.1**: Ktor 플러그인 기본 구조

## 📊 파일 변경사항
- **8개 파일** 변경
- **190개 라인** 추가
- **새로운 core 모듈** 생성
- **4개 새로운 Kotlin 파일** 추가

Closes #64

🤖 Generated with [Claude Code](https://claude.ai/code)