### PR TITLE
[Fix] Fix Ktor 4xx/5xx response mocking exception #102

### DIFF
--- a/lib/src/main/java/net/spooncast/openmocker/lib/data/adapter/KtorAdapter.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/data/adapter/KtorAdapter.kt
@@ -81,8 +81,7 @@ internal class KtorAdapter: HttpClientAdapter<HttpRequestData, HttpResponse> {
                 })
             }
 
-            // ResponseValidator를 이용하여, HttpStatusCode에 따른 Exception 유발
-            expectSuccess = true
+            expectSuccess = false
         }
 
         return runBlocking {


### PR DESCRIPTION
## Summary
- Ktor 어댑터에서 4xx/5xx 상태 코드 모킹 시 예외 발생 문제 해결

## Changes
- \`KtorAdapter\`: \`expectSuccess = false\`로 변경
- 4xx/5xx 응답에서 예외 발생 방지
- 잘못된 주석 제거

## Test Plan
- [x] \`./gradlew :lib:build\` 빌드 성공
- [ ] 데모 앱에서 4xx/5xx 모킹 시 예외 없이 응답 반환 확인

## Related Issue
Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)