### PR TITLE
[Refactor] Make extractResponseData suspend function

### DIFF
--- a/lib/src/main/java/net/spooncast/openmocker/lib/client/okhttp/OpenMockerInterceptor.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/client/okhttp/OpenMockerInterceptor.kt
@@ -27,7 +27,7 @@ class OpenMockerInterceptor private constructor(
         }
 
         val response = chain.proceed(request)
-        mockingEngine.cacheResponse(request, response)
+        runBlocking { mockingEngine.cacheResponse(request, response) }
 
         return response
     }

--- a/lib/src/main/java/net/spooncast/openmocker/lib/data/MockingEngine.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/data/MockingEngine.kt
@@ -8,7 +8,7 @@ internal class MockingEngine<TRequest, TResponse>(
     private val cacheRepo: CacheRepo,
     private val clientAdapter: HttpClientAdapter<TRequest, TResponse>
 ) {
-    fun cacheResponse(clientRequest: TRequest, clientResponse: TResponse) {
+    suspend fun cacheResponse(clientRequest: TRequest, clientResponse: TResponse) {
         val requestData = clientAdapter.extractRequestData(clientRequest)
         val responseData = clientAdapter.extractResponseData(clientResponse)
 

--- a/lib/src/main/java/net/spooncast/openmocker/lib/data/adapter/HttpClientAdapter.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/data/adapter/HttpClientAdapter.kt
@@ -6,6 +6,6 @@ import net.spooncast.openmocker.lib.model.HttpResp
 
 internal interface HttpClientAdapter<TRequest, TResponse> {
     fun extractRequestData(clientRequest: TRequest): HttpReq
-    fun extractResponseData(clientResponse: TResponse): HttpResp
+    suspend fun extractResponseData(clientResponse: TResponse): HttpResp
     fun createMockResponse(originalRequest: TRequest, mockResponse: CachedResponse): TResponse
 }

--- a/lib/src/main/java/net/spooncast/openmocker/lib/data/adapter/KtorAdapter.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/data/adapter/KtorAdapter.kt
@@ -37,11 +37,9 @@ internal class KtorAdapter: HttpClientAdapter<HttpRequestData, HttpResponse> {
         )
     }
 
-    override fun extractResponseData(clientResponse: HttpResponse): HttpResp {
+    override suspend fun extractResponseData(clientResponse: HttpResponse): HttpResp {
         val body = try {
-            runBlocking {
-                clientResponse.bodyAsText()
-            }
+            clientResponse.bodyAsText()
         } catch (e: Exception) {
             // Fallback to empty body if reading fails
             ""

--- a/lib/src/main/java/net/spooncast/openmocker/lib/data/adapter/OkHttpAdapter.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/data/adapter/OkHttpAdapter.kt
@@ -18,7 +18,7 @@ internal class OkHttpAdapter : HttpClientAdapter<Request, Response> {
         )
     }
 
-    override fun extractResponseData(clientResponse: Response): HttpResp {
+    override suspend fun extractResponseData(clientResponse: Response): HttpResp {
         val body = try {
             clientResponse.peekBody(Long.MAX_VALUE).string()
         } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- Suspend 함수 개선으로 비동기 처리 최적화

## Changes
- \`HttpClientAdapter\`: \`extractResponseData\`를 suspend 함수로 변경
- \`KtorAdapter\`: runBlocking 제거하여 비동기 처리 개선
- \`OkHttpAdapter\`: 인터페이스 변경 반영
- \`MockingEngine\`: \`cacheResponse\`를 suspend 함수로 변경
- \`OpenMockerInterceptor\`: runBlocking 추가

## Test Plan
- [x] \`./gradlew clean build -x test\` 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)