### PR TITLE
[Fix] KtorAdapter expectSuccess로 인한 4xx/5xx mock 응답 크래시 수정

### DIFF
--- a/lib/src/main/java/net/spooncast/openmocker/lib/data/adapter/KtorAdapter.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/data/adapter/KtorAdapter.kt
@@ -81,8 +81,7 @@ internal class KtorAdapter: HttpClientAdapter<HttpRequestData, HttpResponse> {
                 })
             }
 
-            // ResponseValidator를 이용하여, HttpStatusCode에 따른 Exception 유발
-            expectSuccess = true
+            expectSuccess = false
         }
 
         return runBlocking {

--- a/lib/src/test/java/net/spooncast/openmocker/lib/data/adapter/KtorAdapterTest.kt
+++ b/lib/src/test/java/net/spooncast/openmocker/lib/data/adapter/KtorAdapterTest.kt
@@ -1,0 +1,79 @@
+package net.spooncast.openmocker.lib.data.adapter
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import net.spooncast.openmocker.lib.model.CachedResponse
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class KtorAdapterTest {
+
+    private val sut = KtorAdapter()
+
+    private fun captureRequestData(): HttpRequestData {
+        var captured: HttpRequestData? = null
+        val engine = MockEngine { request ->
+            captured = request
+            respond("", HttpStatusCode.OK, headersOf())
+        }
+        val client = HttpClient(engine)
+        runBlocking {
+            client.get("https://api.example.com/v1/test")
+        }
+        client.close()
+        return captured!!
+    }
+
+    @Nested
+    @DisplayName("createMockResponse()")
+    inner class CreateMockResponseTest {
+
+        @ParameterizedTest
+        @ValueSource(ints = [200, 400, 404, 500, 503])
+        @DisplayName("""
+            [GIVEN: mock 응답의 상태 코드가 주어진 상태]
+            [WHEN: createMockResponse 호출]
+            [THEN: 예외 없이 해당 상태 코드의 HttpResponse를 반환한다]""")
+        fun `returns response with matching status code without exception`(statusCode: Int) = runBlocking {
+            val mockBody = """{"error": "test error message"}"""
+            val cachedResponse = CachedResponse(
+                code = statusCode,
+                body = mockBody
+            )
+            val request = captureRequestData()
+
+            val response = sut.createMockResponse(request, cachedResponse)
+
+            assertEquals(statusCode, response.status.value)
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = [200, 400, 404, 500, 503])
+        @DisplayName("""
+            [GIVEN: mock 응답의 body가 주어진 상태]
+            [WHEN: createMockResponse 호출]
+            [THEN: 반환된 응답의 body가 입력 mock body와 일치한다]""")
+        fun `returns response with matching body`(statusCode: Int) = runBlocking {
+            val mockBody = """{"message": "test"}"""
+            val cachedResponse = CachedResponse(
+                code = statusCode,
+                body = mockBody
+            )
+            val request = captureRequestData()
+
+            val response = sut.createMockResponse(request, cachedResponse)
+
+            assertEquals(mockBody, response.bodyAsText())
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `KtorAdapter.createMockResponse`에서 `expectSuccess = true` → `false`로 변경하여 4xx/5xx 상태 코드 mock 응답 시 크래시 수정
- `KtorAdapterTest` 추가: 상태 코드 200/400/404/500/503에서 예외 없이 올바른 응답 반환 검증

Closes #107

## Test plan
- [x] `./gradlew :lib:testDebugUnitTest --tests "net.spooncast.openmocker.lib.data.adapter.KtorAdapterTest"` 통과 확인
- [ ] 앱에서 Ktor 클라이언트로 4xx/5xx mock 응답 설정 후 크래시 없이 반환되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)