### PR TITLE
feat: T2 EventSink + SinkRegistry를 release/0.1.0로 복원 (#116)

### DIFF
--- a/lib/src/main/java/net/spooncast/openmocker/lib/control/OpenMockerEventSink.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/control/OpenMockerEventSink.kt
@@ -1,0 +1,30 @@
+package net.spooncast.openmocker.lib.control
+
+/**
+ * HTTP 범위 밖의 이벤트(예: WebSocket/WALA)를 앱이 OpenMocker 제어 통로에 연결하기 위한 범용 추상화.
+ *
+ * 앱이 이 인터페이스를 구현해 [net.spooncast.openmocker.lib.OpenMocker.registerSink] 로 등록하면,
+ * 제어 서버가 `POST /inject/{id}` 로 받은 raw payload 를 파싱 없이 [inject] 로 그대로 전달한다.
+ */
+interface OpenMockerEventSink {
+    /** 레지스트리 키. `POST /inject/{id}` 의 `{id}` 와 매칭된다. */
+    val id: String
+
+    /** 사람이 읽는 표시 이름(플러그인 UI 용). */
+    val name: String
+
+    /**
+     * raw payload 를 sink 로 주입한다. 제어 서버는 본문을 해석하지 않고 통째로 전달하며,
+     * 해석은 전적으로 sink 구현(앱)의 책임이다.
+     */
+    fun inject(payload: String)
+
+    /** 플러그인 UI 가 버튼으로 노출할 미리 정의된 payload 목록(편의 기능). 없으면 빈 목록. */
+    fun presets(): List<Preset>
+}
+
+/** 미리 정의된 주입 payload. [OpenMockerEventSink.presets] 가 반환한다. */
+data class Preset(
+    val name: String,
+    val payload: String,
+)

--- a/lib/src/main/java/net/spooncast/openmocker/lib/control/SinkRegistry.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/control/SinkRegistry.kt
@@ -1,0 +1,39 @@
+package net.spooncast.openmocker.lib.control
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * [OpenMockerEventSink] 를 id 키로 보관하는 in-memory 싱글톤(thread-safe).
+ *
+ * 제어 서버가 `GET /inject/sinks` 로 목록을, `POST /inject/{id}` 로 특정 sink 를 조회한다.
+ * 같은 id 로 재등록하면 마지막 등록이 이긴다(last-wins).
+ */
+internal object SinkRegistry {
+
+    private val sinks = ConcurrentHashMap<String, OpenMockerEventSink>()
+
+    /** sink 를 id 키로 등록한다. 같은 id 가 이미 있으면 덮어쓴다(last-wins). */
+    fun register(sink: OpenMockerEventSink) {
+        sinks[sink.id] = sink
+    }
+
+    /** 해당 id 의 sink 를 해제한다. */
+    fun unregister(id: String) {
+        sinks.remove(id)
+    }
+
+    /** 해당 id 의 sink 를 조회한다. 없으면 null. */
+    fun get(id: String): OpenMockerEventSink? {
+        return sinks[id]
+    }
+
+    /** 등록된 모든 sink 의 스냅샷. */
+    fun all(): List<OpenMockerEventSink> {
+        return sinks.values.toList()
+    }
+
+    /** 전체 비운다(주로 테스트용). */
+    fun clear() {
+        sinks.clear()
+    }
+}

--- a/lib/src/test/java/net/spooncast/openmocker/lib/control/SinkRegistryTest.kt
+++ b/lib/src/test/java/net/spooncast/openmocker/lib/control/SinkRegistryTest.kt
@@ -1,0 +1,80 @@
+package net.spooncast.openmocker.lib.control
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SinkRegistryTest {
+
+    // SinkRegistry 는 object 싱글톤이므로 각 테스트 전에 상태를 비운다.
+    @BeforeEach
+    fun setUp() {
+        SinkRegistry.clear()
+    }
+
+    private fun fakeSink(id: String, name: String = id) = object : OpenMockerEventSink {
+        override val id: String = id
+        override val name: String = name
+        override fun inject(payload: String) = Unit
+        override fun presets(): List<Preset> = emptyList()
+    }
+
+    @Test
+    fun `register 후 get 으로 동일 sink 를 조회한다`() {
+        val sink = fakeSink("wala")
+
+        SinkRegistry.register(sink)
+
+        assertSame(sink, SinkRegistry.get("wala"))
+    }
+
+    @Test
+    fun `register 한 sink 는 all 에 포함된다`() {
+        val a = fakeSink("a")
+        val b = fakeSink("b")
+
+        SinkRegistry.register(a)
+        SinkRegistry.register(b)
+
+        val all = SinkRegistry.all()
+        assertEquals(2, all.size)
+        assertTrue(all.containsAll(listOf(a, b)))
+    }
+
+    @Test
+    fun `unregister 후 get 은 null 이고 all 에서 빠진다`() {
+        val sink = fakeSink("wala")
+        SinkRegistry.register(sink)
+
+        SinkRegistry.unregister("wala")
+
+        assertNull(SinkRegistry.get("wala"))
+        assertFalse(SinkRegistry.all().contains(sink))
+    }
+
+    @Test
+    fun `같은 id 재등록 시 마지막 sink 가 이긴다 (last-wins)`() {
+        val first = fakeSink("wala", name = "first")
+        val second = fakeSink("wala", name = "second")
+
+        SinkRegistry.register(first)
+        SinkRegistry.register(second)
+
+        assertSame(second, SinkRegistry.get("wala"))
+        assertEquals(1, SinkRegistry.all().size)
+    }
+
+    @Test
+    fun `clear 후 all 은 비어있다`() {
+        SinkRegistry.register(fakeSink("a"))
+        SinkRegistry.register(fakeSink("b"))
+
+        SinkRegistry.clear()
+
+        assertTrue(SinkRegistry.all().isEmpty())
+    }
+}


### PR DESCRIPTION
## 배경
T2(#116)가 PR #133에서 `main`으로 잘못 머지되었다. M0 작업은 모두 `release/0.1.0`로 통합되어야 하므로, 해당 작업을 이 브랜치로 복원한다.

## 변경
- main의 squash 커밋 20c8d65(`control/OpenMockerEventSink.kt`, `control/SinkRegistry.kt`, test)을 release/0.1.0로 cherry-pick.

## 관련
- main에서의 revert는 별도 PR로 진행.
- T3(#117)는 이 PR 머지 후 release/0.1.0에서 분기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)