### PR TITLE
Control DTO + ControlService 추가

### DIFF
--- a/lib/src/main/java/net/spooncast/openmocker/lib/control/ControlService.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/control/ControlService.kt
@@ -1,0 +1,92 @@
+package net.spooncast.openmocker.lib.control
+
+import net.spooncast.openmocker.lib.control.dto.MockRequestDto
+import net.spooncast.openmocker.lib.control.dto.MockDto
+import net.spooncast.openmocker.lib.control.dto.PresetDto
+import net.spooncast.openmocker.lib.control.dto.RecordedEntryDto
+import net.spooncast.openmocker.lib.control.dto.ResponseDto
+import net.spooncast.openmocker.lib.control.dto.SinkDto
+import net.spooncast.openmocker.lib.data.repo.CacheRepo
+import net.spooncast.openmocker.lib.model.CachedKey
+
+/**
+ * 제어 contract 의 도메인 동작을 담당한다. HTTP/소켓/직렬화는 모르고([ControlServer] 책임),
+ * [CacheRepo] 와 [SinkRegistry] 호출로 각 라우트를 매핑하며 내부 모델 ↔ DTO 변환만 수행한다.
+ *
+ * HTTP 와 분리되어 있어 순수 단위 테스트가 가능하다.
+ */
+internal class ControlService(
+    private val cacheRepo: CacheRepo,
+    private val sinkRegistry: SinkRegistry = SinkRegistry,
+) {
+
+    /**
+     * `GET /rest/recorded` — 기록된 모든 항목을 DTO 로 반환한다.
+     *
+     * `cachedMap` 은 Compose `SnapshotStateMap` 일 수 있어, 순회 중 변경되면 CME 가 날 수 있다.
+     * `toMap()` 으로 방어 복사한 스냅샷을 매핑한다.
+     */
+    fun recorded(): List<RecordedEntryDto> {
+        return cacheRepo.cachedMap.toMap().map { (key, value) ->
+            RecordedEntryDto(
+                method = key.method,
+                path = key.path,
+                response = ResponseDto(
+                    code = value.response.code,
+                    body = value.response.body,
+                ),
+                mock = value.mock?.let { mock ->
+                    MockDto(
+                        code = mock.code,
+                        body = mock.body,
+                        duration = mock.duration,
+                    )
+                },
+            )
+        }
+    }
+
+    /** `POST /rest/mock` — create-or-update 로 mock 을 설정한다. */
+    fun upsertMock(req: MockRequestDto): Boolean {
+        return cacheRepo.upsertMock(
+            method = req.method,
+            urlPath = req.path,
+            code = req.code,
+            body = req.body,
+            duration = req.duration,
+        )
+    }
+
+    /** `DELETE /rest/mock?method=&path=` — 해당 키의 mock 을 해제한다(키가 없으면 false). */
+    fun unMock(method: String, path: String): Boolean {
+        return cacheRepo.unMock(CachedKey(method, path))
+    }
+
+    /** `DELETE /rest/mock?all=true` — 기록/ mock 전체를 비운다. */
+    fun clearAll() {
+        cacheRepo.clearCache()
+    }
+
+    /** `GET /inject/sinks` — 등록된 sink 목록을 DTO 로 반환한다. */
+    fun sinks(): List<SinkDto> {
+        return sinkRegistry.all().map { sink ->
+            SinkDto(
+                id = sink.id,
+                name = sink.name,
+                presets = sink.presets().map { preset ->
+                    PresetDto(name = preset.name, payload = preset.payload)
+                },
+            )
+        }
+    }
+
+    /**
+     * `POST /inject/{id}` — 해당 sink 에 raw payload 를 주입한다.
+     * 등록되지 않은 id 면 false 를 반환한다.
+     */
+    fun inject(id: String, payload: String): Boolean {
+        val sink = sinkRegistry.get(id) ?: return false
+        sink.inject(payload)
+        return true
+    }
+}

--- a/lib/src/main/java/net/spooncast/openmocker/lib/control/dto/ControlDtos.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/control/dto/ControlDtos.kt
@@ -1,0 +1,69 @@
+package net.spooncast.openmocker.lib.control.dto
+
+import kotlinx.serialization.Serializable
+
+/**
+ * 제어 서버(localhost:8099) 의 동결된 API contract 를 표현하는 직렬화 DTO 모음.
+ *
+ * 내부 모델([net.spooncast.openmocker.lib.model])과 분리해, 외부에 노출되는 JSON 형태를
+ * contract 에 고정한다. 직렬화/역직렬화는 ControlServer 가 담당하고, 이 DTO 들은 그 경계의
+ * 데이터 형태만 정의한다.
+ */
+
+/**
+ * `GET /rest/recorded` 응답 한 항목. 기록된 원본 응답([response])과, 설정되어 있으면
+ * 현재 mock([mock])을 함께 담는다.
+ */
+@Serializable
+internal data class RecordedEntryDto(
+    val method: String,
+    val path: String,
+    val response: ResponseDto,
+    val mock: MockDto? = null,
+)
+
+/** 기록된 원본 응답(관측값). */
+@Serializable
+internal data class ResponseDto(
+    val code: Int,
+    val body: String,
+)
+
+/** 현재 설정된 mock 응답. */
+@Serializable
+internal data class MockDto(
+    val code: Int,
+    val body: String,
+    val duration: Long,
+)
+
+/** `POST /rest/mock` 요청 바디. create-or-update 로 mock 을 설정한다. */
+@Serializable
+internal data class MockRequestDto(
+    val method: String,
+    val path: String,
+    val code: Int,
+    val body: String,
+    val duration: Long = 0L,
+)
+
+/** `GET /inject/sinks` 응답 한 항목. 등록된 [OpenMockerEventSink] 의 노출 정보. */
+@Serializable
+internal data class SinkDto(
+    val id: String,
+    val name: String,
+    val presets: List<PresetDto>,
+)
+
+/** sink 가 제공하는 미리 정의된 주입 payload. */
+@Serializable
+internal data class PresetDto(
+    val name: String,
+    val payload: String,
+)
+
+/** 성공 응답 공용 바디(`{"ok":true}`). */
+@Serializable
+internal data class OkDto(
+    val ok: Boolean = true,
+)

--- a/lib/src/test/java/net/spooncast/openmocker/lib/control/ControlServiceTest.kt
+++ b/lib/src/test/java/net/spooncast/openmocker/lib/control/ControlServiceTest.kt
@@ -1,0 +1,152 @@
+package net.spooncast.openmocker.lib.control
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.spooncast.openmocker.lib.control.dto.MockRequestDto
+import net.spooncast.openmocker.lib.data.repo.CacheRepo
+import net.spooncast.openmocker.lib.model.CachedKey
+import net.spooncast.openmocker.lib.model.CachedResponse
+import net.spooncast.openmocker.lib.model.CachedValue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ControlServiceTest {
+
+    private val cacheRepo = mockk<CacheRepo>(relaxed = true)
+
+    // SinkRegistry 는 object 싱글톤이므로 각 테스트 전에 상태를 비운다.
+    private val service = ControlService(cacheRepo, SinkRegistry)
+
+    @BeforeEach
+    fun setUp() {
+        SinkRegistry.clear()
+    }
+
+    private fun fakeSink(
+        id: String,
+        name: String = id,
+        presets: List<Preset> = emptyList(),
+    ) = object : OpenMockerEventSink {
+        override val id: String = id
+        override val name: String = name
+        override fun inject(payload: String) = Unit
+        override fun presets(): List<Preset> = presets
+    }
+
+    @Test
+    fun `recorded 는 mock 이 없으면 mock 을 null 로 변환한다`() {
+        every { cacheRepo.cachedMap } returns mapOf(
+            CachedKey("GET", "/users") to CachedValue(
+                response = CachedResponse(200, "{\"id\":1}"),
+            ),
+        )
+
+        val result = service.recorded()
+
+        assertEquals(1, result.size)
+        val entry = result.first()
+        assertEquals("GET", entry.method)
+        assertEquals("/users", entry.path)
+        assertEquals(200, entry.response.code)
+        assertEquals("{\"id\":1}", entry.response.body)
+        assertNull(entry.mock)
+    }
+
+    @Test
+    fun `recorded 는 mock 이 있으면 MockDto 로 변환한다`() {
+        every { cacheRepo.cachedMap } returns mapOf(
+            CachedKey("POST", "/live") to CachedValue(
+                response = CachedResponse(200, "original"),
+                mock = CachedResponse(500, "mocked", duration = 1000L),
+            ),
+        )
+
+        val entry = service.recorded().first()
+
+        assertEquals(200, entry.response.code)
+        assertEquals("original", entry.response.body)
+        assertEquals(500, entry.mock?.code)
+        assertEquals("mocked", entry.mock?.body)
+        assertEquals(1000L, entry.mock?.duration)
+    }
+
+    @Test
+    fun `upsertMock 은 cacheRepo 에 위임하고 결과를 반환한다`() {
+        every {
+            cacheRepo.upsertMock("GET", "/live", 500, "{}", 0L)
+        } returns true
+
+        val result = service.upsertMock(
+            MockRequestDto(method = "GET", path = "/live", code = 500, body = "{}"),
+        )
+
+        assertTrue(result)
+        verify { cacheRepo.upsertMock("GET", "/live", 500, "{}", 0L) }
+    }
+
+    @Test
+    fun `unMock 은 CachedKey 를 만들어 cacheRepo 에 위임한다`() {
+        every { cacheRepo.unMock(CachedKey("GET", "/live")) } returns true
+
+        val result = service.unMock("GET", "/live")
+
+        assertTrue(result)
+        verify { cacheRepo.unMock(CachedKey("GET", "/live")) }
+    }
+
+    @Test
+    fun `clearAll 은 cacheRepo clearCache 에 위임한다`() {
+        service.clearAll()
+
+        verify { cacheRepo.clearCache() }
+    }
+
+    @Test
+    fun `sinks 는 등록된 sink 와 preset 을 DTO 로 변환한다`() {
+        SinkRegistry.register(
+            fakeSink(
+                id = "wala",
+                name = "WALA",
+                presets = listOf(Preset("room_close", "{\"type\":\"close\"}")),
+            ),
+        )
+
+        val sinks = service.sinks()
+
+        assertEquals(1, sinks.size)
+        val dto = sinks.first()
+        assertEquals("wala", dto.id)
+        assertEquals("WALA", dto.name)
+        assertEquals(1, dto.presets.size)
+        assertEquals("room_close", dto.presets.first().name)
+        assertEquals("{\"type\":\"close\"}", dto.presets.first().payload)
+    }
+
+    @Test
+    fun `inject 는 등록된 sink 에 payload 를 전달하고 true 를 반환한다`() {
+        var injected: String? = null
+        SinkRegistry.register(object : OpenMockerEventSink {
+            override val id: String = "wala"
+            override val name: String = "WALA"
+            override fun inject(payload: String) { injected = payload }
+            override fun presets(): List<Preset> = emptyList()
+        })
+
+        val result = service.inject("wala", "raw-payload")
+
+        assertTrue(result)
+        assertEquals("raw-payload", injected)
+    }
+
+    @Test
+    fun `inject 는 미등록 id 면 false 를 반환한다`() {
+        val result = service.inject("unknown", "raw-payload")
+
+        assertFalse(result)
+    }
+}


### PR DESCRIPTION
## Meta

PR Type: feature

Closes #117

## 문제/신규 기능 설명

외부 제어 contract(localhost:8099)의 **도메인 동작을 HTTP/소켓/직렬화와 분리**한 `ControlService`와, contract를 표현하는 `@Serializable` DTO를 추가한다. 직렬화 경계와 ServerSocket은 다음 작업(T4 `ControlServer`, #118)이 담당하며, 이 PR은 순수 도메인 로직과 DTO만 다뤄 단위 테스트 가능하게 한다.

## 적용 버전

해당 없음 (버전 상향은 T8 #122에서 처리)

## 원인

신규 기능 — 해당 없음

## 수정/구현

- **DTO (`control/dto/ControlDtos.kt`)** — contract와 1:1 매핑되는 `@Serializable internal` 7종: `RecordedEntryDto`/`ResponseDto`/`MockDto`, `MockRequestDto`, `SinkDto`/`PresetDto`, `OkDto`.
- **`control/ControlService.kt`** — `(CacheRepo, SinkRegistry)` 주입. 각 라우트를 repo/registry 호출로 위임 + 내부 모델↔DTO 변환:

  | 메서드 | 매핑 |
  |---|---|
  | `recorded()` | `cachedMap` → `[RecordedEntryDto]` |
  | `upsertMock(req)` | `cacheRepo.upsertMock(...)` |
  | `unMock(method, path)` | `CachedKey` 생성 후 `cacheRepo.unMock(key)` |
  | `clearAll()` | `cacheRepo.clearCache()` |
  | `sinks()` | `sinkRegistry.all()` → `[SinkDto]` |
  | `inject(id, payload)` | `sinkRegistry.get(id)?.inject(...)` ?: false |

- **`ControlServiceTest.kt`** — 9개 테스트. `CacheRepo`=mockk, `SinkRegistry`=실객체+clear.
- **리뷰 포인트**:
  - `recorded()`는 `cachedMap.toMap()` 방어 복사로 Compose `SnapshotStateMap` 순회 중 CME를 회피.
  - `SinkRegistry`가 `object`라 `ControlService` 생성자에 기본값(`= SinkRegistry`)으로 주입 — 테스트에서 실객체 교체/clear 가능.

## 의존

- T1 #115 `upsertMock` (release/0.1.0 머지 완료), T2 #116 `SinkRegistry` (#134로 release/0.1.0 머지 완료).
