### PR TITLE
ControlServer (raw ServerSocket HTTP/1.1) + 코루틴 의존성 추가

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ serializationJson = "1.7.3"
 gson = "2.11.0"
 ktor = "3.0.0"
 mockk = "1.13.8"
+coroutines = "1.9.0"
 
 [libraries]
 # AndroidX
@@ -67,6 +68,9 @@ jetbrains-kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name =
 
 # Gson
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
+
+# Coroutines
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 
 # Ktor
 ktor-client-android = { group = "io.ktor", name = "ktor-client-android", version.ref = "ktor" }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -96,6 +96,9 @@ dependencies {
     implementation(libs.ktor.client.serialization)
     testImplementation(libs.ktor.client.mock)
 
+    // Coroutines
+    implementation(libs.kotlinx.coroutines.core)
+
     // Serialization
     implementation(libs.jetbrains.kotlinx.serialization.json)
 

--- a/lib/src/main/java/net/spooncast/openmocker/lib/control/ControlServer.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/control/ControlServer.kt
@@ -1,0 +1,290 @@
+package net.spooncast.openmocker.lib.control
+
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import net.spooncast.openmocker.lib.control.dto.MockRequestDto
+import net.spooncast.openmocker.lib.control.dto.OkDto
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.URLDecoder
+
+/**
+ * 임베디드 raw-socket HTTP/1.1 제어 서버. 외부 의존(임베디드 서버 라이브러리) 없이 `ServerSocket`
+ * accept 루프만으로 제어 contract 를 수신한다. HTTP/소켓/직렬화는 이 클래스가 전담하고, 도메인
+ * 동작은 [ControlService] 에 위임한다.
+ *
+ * - loopback 전용 bind (데스크톱은 `adb forward` 로 접속) → 외부 노출 없음.
+ * - bind 실패는 throw 하지 않고 [Log] 로 남긴 뒤 noop — 디버그용 서버 실패가 앱 기동을 깨면 안 된다.
+ * - 커넥션당 요청 1건, 응답 후 `Connection: close`.
+ */
+internal class ControlServer(
+    private val service: ControlService,
+) {
+
+    private val lock = Any()
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    private var serverSocket: ServerSocket? = null
+    private var scope: CoroutineScope? = null
+
+    @Volatile
+    private var running = false
+
+    /**
+     * 제어 서버를 시작한다. 이미 실행 중이면 멱등하게 무시한다.
+     * bind 실패 시 예외를 던지지 않고 로깅 후 비활성 상태로 둔다.
+     */
+    fun start(port: Int = DEFAULT_PORT) {
+        synchronized(lock) {
+            if (running) return
+
+            val server = try {
+                ServerSocket().apply {
+                    bind(InetSocketAddress(InetAddress.getLoopbackAddress(), port))
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to bind control server on port $port; server disabled", e)
+                return
+            }
+
+            val serverScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+            serverSocket = server
+            scope = serverScope
+            running = true
+
+            serverScope.launch {
+                while (isActive) {
+                    val socket = try {
+                        server.accept()
+                    } catch (e: Exception) {
+                        // stop() 이 소켓을 닫으면 accept() 가 SocketException → 루프 정상 종료.
+                        break
+                    }
+                    launch { handle(socket) }
+                }
+            }
+        }
+    }
+
+    /** 제어 서버를 멈춘다. 실행 중이 아니면 멱등하게 무시한다. */
+    fun stop() {
+        synchronized(lock) {
+            if (!running) return
+            running = false
+            try {
+                serverSocket?.close()
+            } catch (_: Exception) {
+                // 닫는 중 발생한 예외는 무시한다.
+            }
+            serverSocket = null
+            scope?.cancel()
+            scope = null
+        }
+    }
+
+    private fun handle(socket: Socket) {
+        socket.use { s ->
+            val output = s.getOutputStream()
+            try {
+                val request = readHttpRequest(s.getInputStream())
+                val (status, body) = route(request)
+                writeResponse(output, status, body)
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to handle control request", e)
+                try {
+                    writeResponse(output, 500, errorBody(e.message ?: "internal error"))
+                } catch (_: Exception) {
+                    // 응답 쓰기 실패는 무시한다(커넥션은 use 로 닫힘).
+                }
+            }
+        }
+    }
+
+    /** 요청라인 + path/query 를 보고 [ControlService] 로 분기한다. 결과는 (status, json body). */
+    private fun route(request: HttpRequest): Pair<Int, String> {
+        val questionIdx = request.target.indexOf('?')
+        val path = if (questionIdx >= 0) request.target.substring(0, questionIdx) else request.target
+        val query = if (questionIdx >= 0) parseQuery(request.target.substring(questionIdx + 1)) else emptyMap()
+
+        return when {
+            request.method == "GET" && path == "/rest/recorded" ->
+                200 to json.encodeToString(service.recorded())
+
+            request.method == "POST" && path == "/rest/mock" -> {
+                val dto = try {
+                    json.decodeFromString<MockRequestDto>(request.body)
+                } catch (e: Exception) {
+                    return 400 to errorBody("invalid body: ${e.message}")
+                }
+                service.upsertMock(dto)
+                200 to json.encodeToString(OkDto())
+            }
+
+            request.method == "DELETE" && path == "/rest/mock" -> {
+                if (query["all"] == "true") {
+                    service.clearAll()
+                } else {
+                    service.unMock(query["method"].orEmpty(), query["path"].orEmpty())
+                }
+                200 to json.encodeToString(OkDto())
+            }
+
+            request.method == "GET" && path == "/inject/sinks" ->
+                200 to json.encodeToString(service.sinks())
+
+            request.method == "POST" && path.startsWith("/inject/") -> {
+                val id = path.removePrefix("/inject/")
+                // body 는 파싱 없이 통째 전달한다.
+                if (service.inject(id, request.body)) {
+                    200 to json.encodeToString(OkDto())
+                } else {
+                    404 to errorBody("unknown sink: $id")
+                }
+            }
+
+            else -> 404 to errorBody("not found: ${request.method} $path")
+        }
+    }
+
+    private fun writeResponse(output: OutputStream, status: Int, body: String) {
+        val bodyBytes = body.toByteArray(Charsets.UTF_8)
+        val head = buildString {
+            append("HTTP/1.1 ").append(status).append(' ').append(reasonPhrase(status)).append("\r\n")
+            append("Content-Type: application/json; charset=utf-8\r\n")
+            append("Content-Length: ").append(bodyBytes.size).append("\r\n")
+            append("Connection: close\r\n")
+            append("\r\n")
+        }
+        output.write(head.toByteArray(Charsets.ISO_8859_1))
+        output.write(bodyBytes)
+        output.flush()
+    }
+
+    private fun errorBody(message: String): String =
+        json.encodeToString(buildJsonObject {
+            put("ok", false)
+            put("error", message)
+        })
+
+    private fun parseQuery(raw: String): Map<String, String> {
+        if (raw.isBlank()) return emptyMap()
+        val result = HashMap<String, String>()
+        for (pair in raw.split("&")) {
+            if (pair.isEmpty()) continue
+            val idx = pair.indexOf('=')
+            val key = if (idx < 0) pair else pair.substring(0, idx)
+            val value = if (idx < 0) "" else pair.substring(idx + 1)
+            result[urlDecode(key)] = urlDecode(value)
+        }
+        return result
+    }
+
+    private fun urlDecode(value: String): String =
+        try {
+            URLDecoder.decode(value, "UTF-8")
+        } catch (e: Exception) {
+            value
+        }
+
+    private fun reasonPhrase(status: Int): String = when (status) {
+        200 -> "OK"
+        400 -> "Bad Request"
+        404 -> "Not Found"
+        else -> "Internal Server Error"
+    }
+
+    companion object {
+        private const val TAG = "OpenMockerControlServer"
+        const val DEFAULT_PORT = 8099
+    }
+}
+
+/** [readHttpRequest] 가 파싱한 요청. [headers] 키는 소문자로 정규화된다. */
+internal data class HttpRequest(
+    val method: String,
+    val target: String,
+    val headers: Map<String, String>,
+    val body: String,
+)
+
+/**
+ * raw [InputStream] 에서 HTTP/1.1 요청 1건을 읽어 [HttpRequest] 로 파싱한다(순수 함수, 단위 테스트 대상).
+ *
+ * head(요청라인 + 헤더)는 CRLF 단위로 직접 읽고, body 는 `Content-Length` 바이트만큼 정확히 읽어
+ * UTF-8 로 디코드한다. `BufferedReader` 를 쓰면 내부 버퍼가 body 바이트까지 미리 삼켜버리는 고전적인
+ * 버그가 생기므로, 바이트 단위로 직접 읽는다.
+ */
+internal fun readHttpRequest(input: InputStream): HttpRequest {
+    // head 끝(\r\n\r\n) 까지 바이트 단위로 읽는다.
+    val headBytes = ByteArrayOutputStream()
+    var matched = 0 // \r\n\r\n 중 현재까지 매칭된 바이트 수
+    while (true) {
+        val b = input.read()
+        if (b == -1) break
+        headBytes.write(b)
+        matched = when {
+            b == CR && (matched == 0 || matched == 2) -> matched + 1
+            b == LF && matched == 1 -> 2
+            b == LF && matched == 3 -> 4
+            else -> 0
+        }
+        if (matched == 4) break
+    }
+
+    // head 는 ASCII/ISO-8859-1 범위 → 라인 분해. (body 만 UTF-8)
+    val head = headBytes.toByteArray().toString(Charsets.ISO_8859_1)
+    val lines = head.split("\r\n")
+
+    val requestLine = lines.firstOrNull()?.trim().orEmpty()
+    val requestParts = requestLine.split(" ")
+    val method = requestParts.getOrNull(0).orEmpty()
+    val target = requestParts.getOrNull(1).orEmpty()
+
+    val headers = HashMap<String, String>()
+    for (i in 1 until lines.size) {
+        val line = lines[i]
+        if (line.isEmpty()) continue
+        val colon = line.indexOf(':')
+        if (colon <= 0) continue
+        val name = line.substring(0, colon).trim().lowercase()
+        val value = line.substring(colon + 1).trim()
+        headers[name] = value
+    }
+
+    val contentLength = headers["content-length"]?.toIntOrNull() ?: 0
+    val body = if (contentLength > 0) {
+        val buffer = ByteArray(contentLength)
+        var read = 0
+        while (read < contentLength) {
+            val n = input.read(buffer, read, contentLength - read)
+            if (n == -1) break
+            read += n
+        }
+        String(buffer, 0, read, Charsets.UTF_8)
+    } else {
+        ""
+    }
+
+    return HttpRequest(method, target, headers, body)
+}
+
+private const val CR = '\r'.code
+private const val LF = '\n'.code

--- a/lib/src/test/java/net/spooncast/openmocker/lib/control/ControlServerTest.kt
+++ b/lib/src/test/java/net/spooncast/openmocker/lib/control/ControlServerTest.kt
@@ -1,0 +1,88 @@
+package net.spooncast.openmocker.lib.control
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+
+/**
+ * [readHttpRequest] 순수 파서 단위 테스트.
+ *
+ * 핵심 검증: head 는 CRLF 로, body 는 `Content-Length` 바이트만큼 정확히 읽고, 멀티바이트 UTF-8
+ * body 가 잘리지 않는다(BufferedReader 삼킴 버그 회피).
+ */
+class ControlServerTest {
+
+    /** head(ISO-8859-1) + body(UTF-8) 를 raw 바이트로 이어붙여 InputStream 으로 만든다. */
+    private fun streamOf(head: String, body: String = ""): InputStream {
+        val bytes = head.toByteArray(Charsets.ISO_8859_1) + body.toByteArray(Charsets.UTF_8)
+        return ByteArrayInputStream(bytes)
+    }
+
+    @Test
+    fun `GET 요청 - 헤더만 있고 body 가 없다`() {
+        val request = readHttpRequest(
+            streamOf("GET /rest/recorded HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        )
+
+        assertEquals("GET", request.method)
+        assertEquals("/rest/recorded", request.target)
+        assertEquals("localhost", request.headers["host"])
+        assertEquals("", request.body)
+    }
+
+    @Test
+    fun `헤더 이름은 소문자로 정규화된다`() {
+        val request = readHttpRequest(
+            streamOf("GET /inject/sinks HTTP/1.1\r\nContent-Type: application/json\r\n\r\n")
+        )
+
+        assertEquals("application/json", request.headers["content-type"])
+    }
+
+    @Test
+    fun `POST 요청 - Content-Length 만큼 body 를 정확히 읽는다`() {
+        val body = """{"method":"GET","path":"/a","code":200,"body":"ok"}"""
+        val head = "POST /rest/mock HTTP/1.1\r\nContent-Length: ${body.toByteArray(Charsets.UTF_8).size}\r\n\r\n"
+
+        val request = readHttpRequest(streamOf(head, body))
+
+        assertEquals("POST", request.method)
+        assertEquals("/rest/mock", request.target)
+        assertEquals(body, request.body)
+    }
+
+    @Test
+    fun `멀티바이트 UTF-8 body 가 잘리지 않는다 - Content-Length 는 바이트 수`() {
+        val body = """{"payload":"한글 페이로드 😀"}"""
+        val byteLength = body.toByteArray(Charsets.UTF_8).size
+        // 바이트 길이와 문자 길이가 다름을 전제로 한다(파서가 바이트로 읽어야 함).
+        assertTrue(byteLength > body.length)
+
+        val head = "POST /inject/wala HTTP/1.1\r\nContent-Length: $byteLength\r\n\r\n"
+        val request = readHttpRequest(streamOf(head, body))
+
+        assertEquals(body, request.body)
+    }
+
+    @Test
+    fun `Content-Length 를 넘는 후속 바이트는 body 에 포함되지 않는다`() {
+        val body = "12345"
+        val head = "POST /inject/x HTTP/1.1\r\nContent-Length: 5\r\n\r\n"
+        // body 뒤에 잉여 바이트를 붙여도 5바이트만 읽어야 한다.
+        val request = readHttpRequest(streamOf(head, body + "TRAILING_GARBAGE"))
+
+        assertEquals("12345", request.body)
+    }
+
+    @Test
+    fun `target 의 path 와 query 가 그대로 보존된다`() {
+        val request = readHttpRequest(
+            streamOf("DELETE /rest/mock?method=GET&path=%2Fa HTTP/1.1\r\n\r\n")
+        )
+
+        assertEquals("DELETE", request.method)
+        assertEquals("/rest/mock?method=GET&path=%2Fa", request.target)
+    }
+}


### PR DESCRIPTION
## Meta

PR Type: feature

Closes #118

## 문제/신규 기능 설명

데스크톱↔앱 제어 통로(HTTP over `adb forward`)를 외부 라이브러리 의존 없이 제공하기 위한
임베디드 제어 서버를 추가한다. raw `ServerSocket` 만으로 제어 contract 를 수신하고, 도메인
동작은 기존 `ControlService`(T3)에 위임한다.

## 적용 버전

해당 없음 (버전 상향은 T8 #122 소관)

## 원인

신규 기능 — 해당 없음

## 수정/구현

- **`control/ControlServer.kt`** (internal) — raw `ServerSocket` accept 루프(`Dispatchers.IO` +
  `SupervisorJob`), 라우팅→`ControlService`, JSON 직렬화, `start`/`stop` 멱등.
  - loopback 전용 bind. **bind 실패 시 throw 대신 `Log` 후 noop** — 디버그 서버 실패가 앱 기동을 깨면 안 됨.
  - `stop()` 이 소켓 close → `accept()` `SocketException` → 루프 정상 종료. `Connection: close`.
- **`readHttpRequest(InputStream)`** — 순수 함수로 분리. head 는 CRLF 바이트 단위, body 는
  `Content-Length` 바이트만큼 정확히 읽어 UTF-8 디코드. ⚠️ `BufferedReader` 가 body 를 삼키는
  고전 버그를 회피한다.
- **코루틴 의존성** — `kotlinx-coroutines-core` 를 명시적 `implementation` 으로 추가
  (`libs.versions.toml` + `lib/build.gradle.kts`). 기존 전이 의존(1.7.3)을 1.9.0 으로 명시 고정.
- **`ControlServerTest`** — `readHttpRequest` 순수 파서 단위 테스트 6건(헤더-only, Content-Length
  정확 읽기, 멀티바이트 UTF-8 비손실, 잉여 바이트 미포함 등).

리뷰 포인트:
- `readHttpRequest` 의 바이트 단위 head/body 분리 정확성.
- accept 루프 종료·`stop()` 멱등성, bind 실패 noop 정책.
- contract 라우팅 표(`GET /rest/recorded`, `POST /rest/mock`, `DELETE /rest/mock`, `GET /inject/sinks`, `POST /inject/{id}`)와 `ControlService` 매핑 일치.
