### PR TITLE
OpenMocker facade 배선 (start/stop/registerSink)

### DIFF
--- a/lib/src/main/java/net/spooncast/openmocker/lib/OpenMocker.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/OpenMocker.kt
@@ -13,12 +13,46 @@ import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import net.spooncast.openmocker.lib.client.okhttp.OpenMockerInterceptor
+import net.spooncast.openmocker.lib.control.ControlServer
+import net.spooncast.openmocker.lib.control.ControlService
+import net.spooncast.openmocker.lib.control.OpenMockerEventSink
+import net.spooncast.openmocker.lib.control.SinkRegistry
+import net.spooncast.openmocker.lib.data.repo.MemCacheRepoImpl
 import net.spooncast.openmocker.lib.ui.OpenMockerActivity
 
 object OpenMocker {
 
+    private var controlServer: ControlServer? = null
+
     fun getInterceptor(): OpenMockerInterceptor {
         return OpenMockerInterceptor.Builder().build()
+    }
+
+    /**
+     * 임베디드 제어 서버를 [port] 에서 시작한다(loopback 전용, opt-in). 이미 실행 중이면 멱등하게 무시한다.
+     * 첫 호출에서 [ControlServer] 를 lazy 생성해 캐시하고, 캐시 저장소([MemCacheRepoImpl]) 와
+     * [SinkRegistry] 를 직접 배선한다 — 내부 모델은 노출하지 않는다.
+     */
+    fun startControlServer(port: Int = ControlServer.DEFAULT_PORT) {
+        val server = controlServer ?: ControlServer(
+            ControlService(MemCacheRepoImpl.getInstance(), SinkRegistry)
+        ).also { controlServer = it }
+        server.start(port)
+    }
+
+    /** 제어 서버를 멈춘다. 실행 중이 아니면 멱등하게 무시한다. */
+    fun stopControlServer() {
+        controlServer?.stop()
+    }
+
+    /** 제어 서버의 `POST /inject/{id}` 로 주입 가능한 [sink] 를 등록한다(같은 id 는 last-wins). */
+    fun registerSink(sink: OpenMockerEventSink) {
+        SinkRegistry.register(sink)
+    }
+
+    /** 해당 [id] 의 sink 등록을 해제한다. */
+    fun unregisterSink(id: String) {
+        SinkRegistry.unregister(id)
     }
 
     fun show(context: Context) {

--- a/lib/src/test/java/net/spooncast/openmocker/lib/OpenMockerControlFacadeTest.kt
+++ b/lib/src/test/java/net/spooncast/openmocker/lib/OpenMockerControlFacadeTest.kt
@@ -1,0 +1,68 @@
+package net.spooncast.openmocker.lib
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.ServerSocket
+import java.net.URL
+
+/**
+ * [OpenMocker] facade 의 제어 서버 배선 통합 테스트(티켓 #119 검증 항목).
+ *
+ * 실제 loopback 소켓을 띄워 검증한다: `startControlServer` 후 `GET /rest/recorded` 가 200 + JSON
+ * 배열로 응답하고, `stopControlServer` 후에는 같은 요청이 연결에 실패한다.
+ */
+@Tag("integration")
+class OpenMockerControlFacadeTest {
+
+    @AfterEach
+    fun tearDown() {
+        // 테스트 격리: 서버가 떠 있으면 반드시 내린다.
+        OpenMocker.stopControlServer()
+    }
+
+    /** OS 가 비어 있는 포트를 고르게 한 뒤 즉시 닫아 그 번호를 반환한다(고정 포트 충돌 회피). */
+    private fun freePort(): Int = ServerSocket(0).use { it.localPort }
+
+    private fun get(port: Int): HttpURLConnection =
+        (URL("http://127.0.0.1:$port/rest/recorded").openConnection() as HttpURLConnection).apply {
+            requestMethod = "GET"
+            connectTimeout = 2_000
+            readTimeout = 2_000
+        }
+
+    @Test
+    fun `startControlServer 후 GET rest_recorded 가 200 JSON 배열로 응답한다`() {
+        val port = freePort()
+        OpenMocker.startControlServer(port)
+
+        val conn = get(port)
+        try {
+            assertEquals(200, conn.responseCode)
+            val body = conn.inputStream.bufferedReader().use { it.readText() }
+            assertTrue(body.trimStart().startsWith("["), "recorded 응답은 JSON 배열이어야 한다: $body")
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    @Test
+    fun `stopControlServer 후에는 연결에 실패한다`() {
+        val port = freePort()
+        OpenMocker.startControlServer(port)
+        // 떠 있는 동안에는 응답한다.
+        get(port).also { assertEquals(200, it.responseCode) }.disconnect()
+
+        OpenMocker.stopControlServer()
+
+        // 내린 뒤에는 연결 자체가 실패한다(connection refused).
+        assertThrows(IOException::class.java) {
+            get(port).responseCode
+        }
+    }
+}


### PR DESCRIPTION
## Meta

PR Type: feature

Closes #119

## 문제/신규 기능 설명

앱이 임베디드 제어 서버를 opt-in 으로 켜고 EventSink 를 등록할 수 있는 진입점을 `OpenMocker` facade 에 추가한다. 이전 task(T2 SinkRegistry / T4 ControlServer)로 갖춰진 제어 패키지를 외부에서 사용할 수 있게 배선하는 단계로, 이것으로 데모/플러그인이 `OpenMocker.startControlServer()` 한 줄로 제어 서버를 띄울 수 있다.

## 적용 버전

0.0.19

## 원인

신규 기능 — 해당 없음

## 수정/구현

- **public API 4종** — `OpenMocker` object 에 `startControlServer(port = 8099)` / `stopControlServer()` / `registerSink(sink)` / `unregisterSink(id)` 추가.
- **배선** — 첫 `startControlServer` 에서 `ControlServer(ControlService(MemCacheRepoImpl.getInstance(), SinkRegistry))` 를 lazy 생성·캐시해 재사용. 멱등성·재기동은 기존 `ControlServer.start/stop` 에 위임(stop 후 다른 포트 재기동 가능).
- **캡슐화 유지** — 공개 시그니처에 노출되는 타입은 public `OpenMockerEventSink` 하나뿐. `ControlServer`/`ControlService`/`SinkRegistry`/`MemCacheRepoImpl` 등 internal 모델은 본문에서만 참조해 비노출.
- **통합 테스트** — `@Tag("integration")` 로 실제 loopback 소켓을 띄워 검증: start 후 `GET /rest/recorded` 200 + JSON 배열, stop 후 연결 실패(`IOException`). 포트 충돌은 `ServerSocket(0)` 로 빈 포트를 먼저 확보해 회피.
- 리뷰 포인트: facade 가 제어 패키지 내부를 수정하지 않고 호출만 하는 얇은 위임 레이어인지, internal 타입 비노출 경계가 지켜지는지.

## 변경 없음

기존 `OpenMocker` API(`getInterceptor`/`show`/알림), 캐시 모델, UI, OkHttp/Ktor 어댑터, 데모앱 배선(T9 #123 별도).
