### PR TITLE
fix: KtorAdapter 결함 수정 (KA-A/B/C/D) (#120)

### DIFF
--- a/lib/src/main/java/net/spooncast/openmocker/lib/data/adapter/KtorAdapter.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/data/adapter/KtorAdapter.kt
@@ -1,6 +1,7 @@
 package net.spooncast.openmocker.lib.data.adapter
 
 import io.ktor.client.HttpClient
+import io.ktor.client.call.save
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -40,7 +41,9 @@ internal class KtorAdapter: HttpClientAdapter<HttpRequestData, HttpResponse> {
     override fun extractResponseData(clientResponse: HttpResponse): HttpResp {
         val body = try {
             runBlocking {
-                clientResponse.bodyAsText()
+                // call.save() 로 응답을 버퍼링한 사본에서 본문을 읽어 원본 채널을 소비하지
+                // 않는다. onResponse 캐싱 경로에서 앱 다운스트림이 본문을 재독할 수 있다(KA-C).
+                clientResponse.call.save().response.bodyAsText()
             }
         } catch (e: Exception) {
             // Fallback to empty body if reading fails
@@ -70,6 +73,8 @@ internal class KtorAdapter: HttpClientAdapter<HttpRequestData, HttpResponse> {
             )
         }
 
+        // MockEngine 핸들러가 per-call CachedResponse(body/code)를 캡처하므로 단일
+        // HttpClient 재사용은 불가능하다. per-call 클라이언트를 만들고 finally 로 close 를 보장한다.
         val client = HttpClient(mockEngine) {
             install(ContentNegotiation) {
                 json(Json {
@@ -81,24 +86,26 @@ internal class KtorAdapter: HttpClientAdapter<HttpRequestData, HttpResponse> {
                 })
             }
 
-            // ResponseValidator를 이용하여, HttpStatusCode에 따른 Exception 유발
-            expectSuccess = true
+            // expectSuccess=true 는 4xx/5xx 에서 ResponseValidator 예외를 던져 mock 에러를
+            // 그대로 반환하지 못하게 한다(KA-B). 제거해 mock 응답을 status 그대로 반환한다.
         }
 
         return runBlocking {
-            val response = client.request {
-                url(originalRequest.url)
-                method = originalRequest.method
-                originalRequest.headers.forEach { key, values ->
-                    headers {
-                        values.forEach { value ->
-                            append(key, value)
+            try {
+                client.request {
+                    url(originalRequest.url)
+                    method = originalRequest.method
+                    originalRequest.headers.forEach { key, values ->
+                        headers {
+                            values.forEach { value ->
+                                append(key, value)
+                            }
                         }
                     }
                 }
+            } finally {
+                client.close()
             }
-            client.close()
-            response
         }
     }
 }

--- a/lib/src/test/java/net/spooncast/openmocker/lib/data/adapter/KtorAdapterTest.kt
+++ b/lib/src/test/java/net/spooncast/openmocker/lib/data/adapter/KtorAdapterTest.kt
@@ -111,4 +111,49 @@ class KtorAdapterTest {
         val body = runBlocking { mock.bodyAsText() }
         assertEquals("{\"mocked\":true}", body)
     }
+
+    @Test
+    fun `createMockResponse 는 4xx mock 을 throw 없이 반환한다`() {
+        val (requestData, _) = exchange("https://api.example.com/x")
+
+        val mock = adapter.createMockResponse(requestData, CachedResponse(code = 404, body = "{\"error\":\"not found\"}"))
+
+        assertEquals(404, mock.status.value)
+        val body = runBlocking { mock.bodyAsText() }
+        assertEquals("{\"error\":\"not found\"}", body)
+    }
+
+    @Test
+    fun `createMockResponse 는 5xx mock 을 throw 없이 반환한다`() {
+        val (requestData, _) = exchange("https://api.example.com/x")
+
+        val mock = adapter.createMockResponse(requestData, CachedResponse(code = 500, body = "server error"))
+
+        assertEquals(500, mock.status.value)
+        val body = runBlocking { mock.bodyAsText() }
+        assertEquals("server error", body)
+    }
+
+    @Test
+    fun `createMockResponse 반복 호출은 예외 없이 안정적으로 동작한다`() {
+        val (requestData, _) = exchange("https://api.example.com/x")
+
+        repeat(100) { i ->
+            val mock = adapter.createMockResponse(requestData, CachedResponse(code = 200, body = "body-$i"))
+            assertEquals(200, mock.status.value)
+            assertEquals("body-$i", runBlocking { mock.bodyAsText() })
+        }
+    }
+
+    @Test
+    fun `extractResponseData 호출 후에도 원본 응답 본문을 다시 읽을 수 있다`() {
+        val (_, response) = exchange("https://api.example.com/x", responseBody = "downstream-body")
+
+        val resp = adapter.extractResponseData(response)
+        assertEquals("downstream-body", resp.body)
+
+        // call.save() 로 비소비 읽기를 했으므로 다운스트림이 본문을 다시 읽을 수 있어야 한다.
+        val reread = runBlocking { response.bodyAsText() }
+        assertEquals("downstream-body", reread)
+    }
 }


### PR DESCRIPTION
## Meta (PR Type)
- [x] Bug fix

상위: #112 [M0] · 해결: #120 [T6]

## 문제 설명
G3 검증 중 발견한 `KtorAdapter.kt`의 실제 결함 4건을 제거한다.

- **KA-B**: 내부 mock 클라이언트가 `expectSuccess = true` 라 4xx/5xx mock 이 ResponseValidator 예외로 throw 되어, mock 에러 응답을 그대로 반환하지 못함 (mock/실제 동작 불일치).
- **KA-A**: `createMockResponse` 에서 `client.close()` 가 평문으로 있어, 요청 중 예외가 나면 close 가 호출되지 않아 클라이언트 누수.
- **KA-D**: per-call `HttpClient(MockEngine)` 의 생명주기/누수 처리 불명확.
- **KA-C**: `extractResponseData` 가 `bodyAsText()` 로 실제 응답 본문 채널을 소비 → `onResponse` 캐싱 경로에서 앱 다운스트림이 본문을 다시 읽지 못함.

## 적용 버전
- `:lib` (ktor 3.0.0)

## 원인
- mock 클라이언트에 `expectSuccess = true` 가 설정되어 에러 status 가 예외로 전환됨 (KA-B).
- close 가 try/finally 로 감싸지지 않아 예외 경로에서 누수 (KA-A).
- MockEngine 핸들러가 per-call `CachedResponse`(body/code)를 캡처하므로 단일 클라이언트 재사용 불가 (KA-D).
- 본문을 원본 채널에서 직접 소비해 재독 불가 (KA-C).

## 수정 / 구현
- **KA-B**: 내부 mock 클라이언트 `expectSuccess = true` 제거 → 4xx/5xx mock 을 status 그대로 반환.
- **KA-A**: `client.request{}` 를 `try { ... } finally { client.close() }` 로 감싸 close 보장.
- **KA-D**: per-call `HttpClient` + finally close 방식으로 확정(재사용 불가 근거 주석 추가).
- **KA-C**: `clientResponse.call.save().response.bodyAsText()` 로 버퍼 사본에서 비소비 읽기 (`import io.ktor.client.call.save` 추가).
- **테스트**: `KtorAdapterTest` 에 회귀 테스트 4건 추가 — 4xx/5xx throw 없이 반환, 반복 호출(100회) 안정성, `extractResponseData` 후 본문 재독 가능.

### 검증
- `./gradlew :lib:testDebugUnitTest --tests "*KtorAdapterTest*"` → **9 tests, 0 failures, 0 errors** · 빌드 성공.

🤖 Generated with [Claude Code](https://claude.com/claude-code)