### PR TITLE
[T7] G3 회귀 테스트 (Ktor + OkHttp)

### DIFF
--- a/lib/src/main/java/net/spooncast/openmocker/lib/data/adapter/KtorAdapter.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/data/adapter/KtorAdapter.kt
@@ -1,6 +1,7 @@
 package net.spooncast.openmocker.lib.data.adapter
 
 import io.ktor.client.HttpClient
+import io.ktor.client.call.save
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -40,7 +41,9 @@ internal class KtorAdapter: HttpClientAdapter<HttpRequestData, HttpResponse> {
     override fun extractResponseData(clientResponse: HttpResponse): HttpResp {
         val body = try {
             runBlocking {
-                clientResponse.bodyAsText()
+                // call.save() 로 응답을 버퍼링한 사본에서 본문을 읽어 원본 채널을 소비하지
+                // 않는다. onResponse 캐싱 경로에서 앱 다운스트림이 본문을 재독할 수 있다(KA-C).
+                clientResponse.call.save().response.bodyAsText()
             }
         } catch (e: Exception) {
             // Fallback to empty body if reading fails
@@ -70,6 +73,8 @@ internal class KtorAdapter: HttpClientAdapter<HttpRequestData, HttpResponse> {
             )
         }
 
+        // MockEngine 핸들러가 per-call CachedResponse(body/code)를 캡처하므로 단일
+        // HttpClient 재사용은 불가능하다. per-call 클라이언트를 만들고 finally 로 close 를 보장한다.
         val client = HttpClient(mockEngine) {
             install(ContentNegotiation) {
                 json(Json {
@@ -81,24 +86,26 @@ internal class KtorAdapter: HttpClientAdapter<HttpRequestData, HttpResponse> {
                 })
             }
 
-            // ResponseValidator를 이용하여, HttpStatusCode에 따른 Exception 유발
-            expectSuccess = true
+            // expectSuccess=true 는 4xx/5xx 에서 ResponseValidator 예외를 던져 mock 에러를
+            // 그대로 반환하지 못하게 한다(KA-B). 제거해 mock 응답을 status 그대로 반환한다.
         }
 
         return runBlocking {
-            val response = client.request {
-                url(originalRequest.url)
-                method = originalRequest.method
-                originalRequest.headers.forEach { key, values ->
-                    headers {
-                        values.forEach { value ->
-                            append(key, value)
+            try {
+                client.request {
+                    url(originalRequest.url)
+                    method = originalRequest.method
+                    originalRequest.headers.forEach { key, values ->
+                        headers {
+                            values.forEach { value ->
+                                append(key, value)
+                            }
                         }
                     }
                 }
+            } finally {
+                client.close()
             }
-            client.close()
-            response
         }
     }
 }

--- a/lib/src/test/java/net/spooncast/openmocker/lib/client/ktor/OpenMockerPluginG3Test.kt
+++ b/lib/src/test/java/net/spooncast/openmocker/lib/client/ktor/OpenMockerPluginG3Test.kt
@@ -1,0 +1,99 @@
+package net.spooncast.openmocker.lib.client.ktor
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.runBlocking
+import net.spooncast.openmocker.lib.data.repo.MemCacheRepoImpl
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * G3 회귀 테스트 (Ktor) — 티켓 #121.
+ *
+ * mock short-circuit 이 응답을 재기록(cache)해 mock 을 지우지 않음을 고정한다.
+ * 시나리오: record → upsertMock → 동일 호출을 여러 번 반복했을 때
+ * (1) 말단(MockEngine = 가짜 서버)이 다시 호출되지 않고(short-circuit),
+ * (2) 매 응답이 mock 값이며,
+ * (3) `cachedMap[key].mock` 이 계속 유지된다.
+ *
+ * 의존: #115 T1(upsertMock).
+ */
+class OpenMockerPluginG3Test {
+
+    private val repo = MemCacheRepoImpl.getInstance()
+
+    /** 말단(가짜 서버) 호출 횟수 — short-circuit 검증용. */
+    private val serverHits = AtomicInteger(0)
+
+    private val serverCode = HttpStatusCode.OK
+    private val serverBody = """{"source":"server"}"""
+
+    // 에러 코드 mock 도 재캐싱에 지워지지 않음을 함께 고정한다(KA-B 픽스 전제: 4xx/5xx mock 무크래시).
+    private val mockCode = 503
+    private val mockBody = """{"source":"mock"}"""
+
+    private val url = "https://api.example.com/v1/users"
+
+    private val client = HttpClient(
+        MockEngine { _ ->
+            serverHits.incrementAndGet()
+            respond(
+                content = ByteReadChannel(serverBody),
+                status = serverCode,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+    ) {
+        install(OpenMockerPlugin)
+    }
+
+    @BeforeEach
+    fun setUp() {
+        // 싱글톤 레포 격리.
+        repo.clearCache()
+        serverHits.set(0)
+    }
+
+    private fun call(): HttpResponse = runBlocking { client.get(url) }
+
+    private fun bodyOf(response: HttpResponse): String = runBlocking { response.bodyAsText() }
+
+    @Test
+    fun `mock 설정 후 반복 호출해도 mock 이 유지되고 서버를 다시 치지 않는다`() {
+        // 1) 첫 호출: 실제 서버를 기록한다.
+        assertEquals(serverCode, call().status, "첫 호출은 실제 서버 응답을 받는다")
+        assertEquals(1, serverHits.get(), "첫 호출은 서버를 한 번 친다")
+
+        // 기록된 실제 CachedKey 로 mock 을 건다(path 포맷 추측 회피).
+        val key = repo.cachedMap.keys.single()
+        repo.upsertMock(key.method, key.path, mockCode, mockBody)
+
+        // 2) 동일 호출을 여러 번 반복한다.
+        repeat(5) {
+            val resp = call()
+            assertEquals(mockCode, resp.status.value, "반복 호출은 mock code 로 short-circuit 돼야 한다")
+            assertEquals(mockBody, bodyOf(resp), "반복 호출은 mock body 를 반환해야 한다")
+        }
+
+        // 3) 서버는 첫 호출 이후 다시 불리지 않았다(mock short-circuit).
+        assertEquals(1, serverHits.get(), "mock 적용 후에는 서버를 다시 치지 않아야 한다")
+
+        // 4) 재기록으로 mock 이 지워지지 않고 유지된다.
+        val mock = repo.cachedMap[key]?.mock
+        assertNotNull(mock, "반복 호출 후에도 mock 이 유지돼야 한다")
+        assertEquals(mockCode, mock!!.code)
+        assertEquals(mockBody, mock.body)
+    }
+}

--- a/lib/src/test/java/net/spooncast/openmocker/lib/client/okhttp/OpenMockerInterceptorG3Test.kt
+++ b/lib/src/test/java/net/spooncast/openmocker/lib/client/okhttp/OpenMockerInterceptorG3Test.kt
@@ -1,0 +1,97 @@
+package net.spooncast.openmocker.lib.client.okhttp
+
+import net.spooncast.openmocker.lib.data.repo.MemCacheRepoImpl
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * G3 회귀 테스트 (OkHttp) — 티켓 #121.
+ *
+ * mock short-circuit 이 응답을 재기록(cache)해 mock 을 지우지 않음을 고정한다.
+ * 시나리오: record → upsertMock → 동일 호출을 여러 번 반복했을 때
+ * (1) 말단(가짜 서버)이 다시 호출되지 않고(short-circuit),
+ * (2) 매 응답이 mock 값이며,
+ * (3) `cachedMap[key].mock` 이 계속 유지된다.
+ *
+ * 의존: #115 T1(upsertMock).
+ */
+class OpenMockerInterceptorG3Test {
+
+    private val repo = MemCacheRepoImpl.getInstance()
+
+    /** 말단(가짜 서버) 호출 횟수 — short-circuit 검증용. */
+    private val serverHits = AtomicInteger(0)
+
+    private val serverCode = 200
+    private val serverBody = """{"source":"server"}"""
+
+    private val mockCode = 503
+    private val mockBody = """{"source":"mock"}"""
+
+    /** 체인 말단에서 실제 네트워크 대신 고정 응답을 돌려주며 호출 횟수를 센다. */
+    private val fakeServer = Interceptor { chain ->
+        serverHits.incrementAndGet()
+        Response.Builder()
+            .request(chain.request())
+            .protocol(Protocol.HTTP_1_1)
+            .code(serverCode)
+            .message("OK")
+            .body(serverBody.toResponseBody("application/json".toMediaType()))
+            .build()
+    }
+
+    private val client = OkHttpClient.Builder()
+        .addInterceptor(OpenMockerInterceptor.Builder().build())
+        .addInterceptor(fakeServer)
+        .build()
+
+    @BeforeEach
+    fun setUp() {
+        // 싱글톤 레포 격리.
+        repo.clearCache()
+        serverHits.set(0)
+    }
+
+    private fun call(): Response =
+        client.newCall(
+            Request.Builder().url("https://api.example.com/v1/users").build()
+        ).execute()
+
+    @Test
+    fun `mock 설정 후 반복 호출해도 mock 이 유지되고 서버를 다시 치지 않는다`() {
+        // 1) 첫 호출: 실제 서버를 기록한다.
+        call().use { assertEquals(serverCode, it.code) }
+        assertEquals(1, serverHits.get(), "첫 호출은 서버를 한 번 친다")
+
+        // 기록된 실제 CachedKey 로 mock 을 건다(path 포맷 추측 회피).
+        val key = repo.cachedMap.keys.single()
+        repo.upsertMock(key.method, key.path, mockCode, mockBody)
+
+        // 2) 동일 호출을 여러 번 반복한다.
+        repeat(5) {
+            call().use { resp ->
+                assertEquals(mockCode, resp.code, "반복 호출은 mock code 로 short-circuit 돼야 한다")
+                assertEquals(mockBody, resp.body!!.string(), "반복 호출은 mock body 를 반환해야 한다")
+            }
+        }
+
+        // 3) 서버는 첫 호출 이후 다시 불리지 않았다(mock short-circuit).
+        assertEquals(1, serverHits.get(), "mock 적용 후에는 서버를 다시 치지 않아야 한다")
+
+        // 4) 재기록으로 mock 이 지워지지 않고 유지된다.
+        val mock = repo.cachedMap[key]?.mock
+        assertNotNull(mock, "반복 호출 후에도 mock 이 유지돼야 한다")
+        assertEquals(mockCode, mock!!.code)
+        assertEquals(mockBody, mock.body)
+    }
+}

--- a/lib/src/test/java/net/spooncast/openmocker/lib/data/adapter/KtorAdapterTest.kt
+++ b/lib/src/test/java/net/spooncast/openmocker/lib/data/adapter/KtorAdapterTest.kt
@@ -111,4 +111,49 @@ class KtorAdapterTest {
         val body = runBlocking { mock.bodyAsText() }
         assertEquals("{\"mocked\":true}", body)
     }
+
+    @Test
+    fun `createMockResponse 는 4xx mock 을 throw 없이 반환한다`() {
+        val (requestData, _) = exchange("https://api.example.com/x")
+
+        val mock = adapter.createMockResponse(requestData, CachedResponse(code = 404, body = "{\"error\":\"not found\"}"))
+
+        assertEquals(404, mock.status.value)
+        val body = runBlocking { mock.bodyAsText() }
+        assertEquals("{\"error\":\"not found\"}", body)
+    }
+
+    @Test
+    fun `createMockResponse 는 5xx mock 을 throw 없이 반환한다`() {
+        val (requestData, _) = exchange("https://api.example.com/x")
+
+        val mock = adapter.createMockResponse(requestData, CachedResponse(code = 500, body = "server error"))
+
+        assertEquals(500, mock.status.value)
+        val body = runBlocking { mock.bodyAsText() }
+        assertEquals("server error", body)
+    }
+
+    @Test
+    fun `createMockResponse 반복 호출은 예외 없이 안정적으로 동작한다`() {
+        val (requestData, _) = exchange("https://api.example.com/x")
+
+        repeat(100) { i ->
+            val mock = adapter.createMockResponse(requestData, CachedResponse(code = 200, body = "body-$i"))
+            assertEquals(200, mock.status.value)
+            assertEquals("body-$i", runBlocking { mock.bodyAsText() })
+        }
+    }
+
+    @Test
+    fun `extractResponseData 호출 후에도 원본 응답 본문을 다시 읽을 수 있다`() {
+        val (_, response) = exchange("https://api.example.com/x", responseBody = "downstream-body")
+
+        val resp = adapter.extractResponseData(response)
+        assertEquals("downstream-body", resp.body)
+
+        // call.save() 로 비소비 읽기를 했으므로 다운스트림이 본문을 다시 읽을 수 있어야 한다.
+        val reread = runBlocking { response.bodyAsText() }
+        assertEquals("downstream-body", reread)
+    }
 }


### PR DESCRIPTION
## Meta

PR Type: bug-fix

Closes #121

## 문제/신규 기능 설명

mock short-circuit 이후의 재기록(cache)이 설정된 mock 을 지워버려, "한 번 mock 을 걸면
다음 호출부터 계속 mock" 보장이 회귀로 깨질 수 있다. 이를 Ktor/OkHttp 양쪽에서 회귀
테스트로 고정한다.

추가로, 본 테스트를 작성하던 중 `release/0.1.0` 에 **KtorAdapter 4xx/5xx mock 크래시
픽스(#120, #139)가 누락**돼 있어 503 mock 시나리오가 깨지는 것을 발견했다. 해당 픽스
커밋을 cherry-pick 으로 함께 반영한다.

## 적용 버전

0.1.0

## 원인

- **재캐싱 회귀**: mock 응답이 응답 파이프라인을 거치며 다시 `cache()` 로 기록되면
  baseline 으로 덮여 `mock` 이 사라질 수 있다 → 회귀 테스트로 고정.
- **KtorAdapter 크래시**: `createMockResponse` 내부 클라이언트의 `expectSuccess = true`
  가 4xx/5xx mock 에서 ResponseValidator 예외를 던짐 → 이 픽스가 release 브랜치에 미반영
  상태였음.

## 수정/구현

- **회귀 테스트 (신규 2건)**
  | 파일 | 검증 |
  |---|---|
  | `client/ktor/OpenMockerPluginG3Test.kt` | record→upsertMock→반복 호출 시 ① 서버 재호출 없음(short-circuit) ② 매 응답 mock ③ `cachedMap[key].mock` 유지. **503 에러 mock** 사용 |
  | `client/okhttp/OpenMockerInterceptorG3Test.kt` | 동일 시나리오(503 mock) |
  - 기법: 첫 record 후 `cachedMap` 에서 실제 `CachedKey` 를 읽어 그 method/path 로
    `upsertMock` → path 포맷 추측 없이 정확히 매칭. 싱글톤 레포는 `@BeforeEach` 에서
    `clearCache()` 로 격리.
- **KtorAdapter 픽스 cherry-pick** (`2d267a4`): `expectSuccess = true` 제거(KA-B),
  per-call 클라이언트 `try/finally` close 보장(KA-A) 등. `KtorAdapterTest` 의 에러 코드
  케이스도 함께 들어옴.
- 리뷰 포인트: cherry-pick 한 `2d267a4` 는 `main` 의 `1e3ad6c` 와 동일 변경이므로,
  추후 main↔release 정리 시 중복 머지로 인식돼도 안전.
