### PR TITLE
[T8] 버전업 + 코루틴 카탈로그

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -148,7 +148,7 @@ publishing {
         register<MavenPublication>("release") {
             groupId = "net.spooncast"
             artifactId = "openmocker"
-            version = "0.0.19"
+            version = "0.1.0"
 
             afterEvaluate {
                 from(components["release"])


### PR DESCRIPTION
## Meta

PR Type: feature

Closes #122

## 문제/신규 기능 설명

M0(#112) 산출물을 새 버전으로 배포 가능하게 하는 마무리 작업.
- 라이브러리 publishing version 상향.
- 코루틴 카탈로그(`gradle/libs.versions.toml`) 정합성 확인.

## 적용 버전

0.1.0

## 원인

신규 기능 — 해당 없음

## 수정/구현

- **버전 상향** — `lib/build.gradle.kts`의 publishing `version` `0.0.19` → `0.1.0` (브랜치 `release/0.1.0`과 정렬).
- **코루틴 카탈로그 (변경 없음)** — `coroutines = "1.9.0"` 및 `kotlinx-coroutines-core` 항목은 T4(#118)에서 이미 추가·배선됨. 정합성 확인만 수행.
- 검증: `./gradlew :lib:assembleRelease` 성공, 생성 POM에 `<version>0.1.0</version>` 반영 확인.
