### PR TITLE
[T9] 데모앱 curl 배선 (DemoApplication)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/
 # Local configuration file (sdk path, etc)
 local.properties
 
+# Secrets (API keys, etc)
+secrets.properties
+
 # Log/OS Files
 *.log
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,6 +42,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     packaging {
         resources {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
@@ -6,6 +8,15 @@ plugins {
     alias(libs.plugins.jetbrains.kotlin.compose)
     alias(libs.plugins.jetbrains.kotlin.serialization)
 }
+
+// secrets.properties (VCS 미추적) 에서 API key 를 읽어 BuildConfig 로 노출한다.
+val secretsFile = rootProject.file("secrets.properties")
+val secrets = Properties().apply {
+    if (secretsFile.exists()) {
+        secretsFile.inputStream().use { load(it) }
+    }
+}
+val weatherApiAppId: String = secrets.getProperty("WEATHER_API_APP_ID", "")
 
 android {
     namespace = "net.spooncast.openmocker.demo"
@@ -22,6 +33,8 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+
+        buildConfigField("String", "WEATHER_API_APP_ID", "\"$weatherApiAppId\"")
     }
 
     buildTypes {

--- a/app/src/main/java/net/spooncast/openmocker/demo/DemoEventSink.kt
+++ b/app/src/main/java/net/spooncast/openmocker/demo/DemoEventSink.kt
@@ -1,0 +1,31 @@
+package net.spooncast.openmocker.demo
+
+import android.util.Log
+import net.spooncast.openmocker.lib.control.OpenMockerEventSink
+import net.spooncast.openmocker.lib.control.Preset
+
+/**
+ * 데모 앱이 제어 서버의 `POST /inject/demo` 통로를 검증하기 위한 예시 sink.
+ *
+ * 실제 WebSocket/WALA 연결이 없는 데모이므로, 주입된 payload 를 [Log] 로 출력해
+ * 제어 서버 → sink 도달 경로만 증명한다. 해석은 하지 않는다.
+ */
+class DemoEventSink : OpenMockerEventSink {
+
+    override val id: String = "demo"
+
+    override val name: String = "Demo Sink"
+
+    override fun inject(payload: String) {
+        Log.d(TAG, "inject payload: $payload")
+    }
+
+    override fun presets(): List<Preset> = listOf(
+        Preset(name = "hello", payload = """{"event":"hello","message":"from demo sink"}"""),
+        Preset(name = "tick", payload = """{"event":"tick","value":1}"""),
+    )
+
+    companion object {
+        private const val TAG = "DemoEventSink"
+    }
+}

--- a/app/src/main/java/net/spooncast/openmocker/demo/di/DemoApplication.kt
+++ b/app/src/main/java/net/spooncast/openmocker/demo/di/DemoApplication.kt
@@ -2,6 +2,21 @@ package net.spooncast.openmocker.demo.di
 
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
+import net.spooncast.openmocker.demo.BuildConfig
+import net.spooncast.openmocker.demo.DemoEventSink
+import net.spooncast.openmocker.lib.OpenMocker
 
 @HiltAndroidApp
-class DemoApplication: Application()
+class DemoApplication: Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+
+        // debug 빌드에서만 임베디드 제어 서버를 띄우고 데모 sink 를 등록한다.
+        // 이 레포만으로 M0 제어 서버를 curl E2E 검증할 수 있게 하는 배선이다.
+        if (BuildConfig.DEBUG) {
+            OpenMocker.startControlServer()
+            OpenMocker.registerSink(DemoEventSink())
+        }
+    }
+}

--- a/app/src/main/java/net/spooncast/openmocker/demo/service/KtorWeatherApiService.kt
+++ b/app/src/main/java/net/spooncast/openmocker/demo/service/KtorWeatherApiService.kt
@@ -4,6 +4,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import net.spooncast.openmocker.demo.BuildConfig
 import net.spooncast.openmocker.demo.model.RespWeather
 import javax.inject.Inject
 
@@ -14,7 +15,7 @@ class KtorWeatherApiService @Inject constructor(
         return client.get("https://api.openweathermap.org/data/2.5/weather") {
             parameter("lat", "44.34")
             parameter("lon", "10.99")
-            parameter("appid", "")
+            parameter("appid", BuildConfig.WEATHER_API_APP_ID)
         }.body()
     }
 }

--- a/app/src/main/java/net/spooncast/openmocker/demo/service/OkHttpWeatherApiService.kt
+++ b/app/src/main/java/net/spooncast/openmocker/demo/service/OkHttpWeatherApiService.kt
@@ -1,5 +1,6 @@
 package net.spooncast.openmocker.demo.service
 
+import net.spooncast.openmocker.demo.BuildConfig
 import net.spooncast.openmocker.demo.model.RespWeather
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -9,7 +10,7 @@ interface OkHttpWeatherApiService {
     suspend fun getCurrentWeather(
         @Query("lat") lat: String = "44.34",
         @Query("lon") lon: String = "10.99",
-        @Query("appid") appId: String = ""
+        @Query("appid") appId: String = BuildConfig.WEATHER_API_APP_ID
     ): RespWeather
 
 }


### PR DESCRIPTION
## Meta

PR Type: feature

Closes #123

## 문제/신규 기능 설명

이 레포만으로 M0 제어 서버를 curl E2E 검증할 수 있도록 데모앱을 배선한다.

- **제어 서버 기동** — `DemoApplication.onCreate`에서 `BuildConfig.DEBUG` 가드로 `OpenMocker.startControlServer()` 호출 + 데모용 `DemoEventSink`(id=`demo`, preset 2개) 등록.
- **weather API appid 주입** — 데모 weather 호출이 실제로 네트워크를 타야 제어 서버가 요청을 기록하므로, 하드코딩된 빈 `appid`를 `secrets.properties` 기반으로 교체.

## 적용 버전

0.1.0

## 원인

신규 기능 — 해당 없음

## 수정/구현

- **제어 서버 배선** (`DemoApplication.kt`) — debug 빌드에서만 제어 서버 기동 + `DemoEventSink` 등록. `BuildConfig.DEBUG` 사용을 위해 `app/build.gradle.kts`에 `buildFeatures { buildConfig = true }` 추가(AGP 8.12.2 기본 OFF).
- **appid 주입** (`secrets.properties` → `BuildConfig`) — `app/build.gradle.kts`가 VCS 미추적 `secrets.properties`에서 `WEATHER_API_APP_ID`를 읽어 `buildConfigField`로 노출. Ktor·OkHttp weather 서비스가 이를 사용. `secrets.properties`는 `.gitignore` 등록.
- **변경 없음** — 데모 weather 로직/UI/DI 구조.

### 리뷰 포인트
- 제어 서버·sink 등록이 `BuildConfig.DEBUG` 가드 안에만 있어 release 빌드에 새지 않는지.
- `secrets.properties` 부재 시 빌드가 깨지지 않고 빈 문자열로 폴백하는지(`getProperty(key, "")`).

### E2E 검증 결과 (실기기 Pixel 6a)
- `GET /rest/recorded` → weather 요청 기록 + appid 실전송 확인
- `POST /rest/mock` → 재호출 시 mock 응답이 앱까지 도달, UI에 `mocked sunny` 표시
- `POST /inject/demo` → `DemoEventSink` 로그 출력, 미등록 sink는 404
