### PR TITLE
[T11] ControlClient + ContractDtos

### DIFF
--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/net/ContractDtos.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/net/ContractDtos.kt
@@ -1,0 +1,56 @@
+package net.spooncast.openmocker.plugin.net
+
+/**
+ * 제어 서버(localhost:8099) 의 동결된 API contract 를 플러그인 쪽에서 미러한 모델.
+ *
+ * :lib 의 `control/dto/ControlDtos.kt` 와 동일한 와이어(JSON) 형태를 표현하되, 플러그인은
+ * 외부 런타임 의존성 0 을 유지하기 위해 kotlinx.serialization 대신 플랫폼 번들 Gson 으로
+ * (역)직렬화한다. Gson 은 프로퍼티명을 그대로 키로 쓰므로 필드명이 contract 와 1:1 로 일치해야
+ * 한다(임의 변경 금지). 서버는 `encodeDefaults = true` / `ignoreUnknownKeys = true` 로 동작한다.
+ */
+
+/**
+ * `GET /rest/recorded` 응답 한 항목. 기록된 원본 응답([response]) 과, 설정되어 있으면
+ * 현재 mock([mock]) 을 함께 담는다. mock 이 없으면 null(키 부재 또는 `mock:null`).
+ */
+data class RecordedEntry(
+    val method: String,
+    val path: String,
+    val response: ResponseData,
+    val mock: MockData? = null,
+)
+
+/** 기록된 원본 응답(관측값). */
+data class ResponseData(
+    val code: Int,
+    val body: String,
+)
+
+/** 현재 설정된 mock 응답. */
+data class MockData(
+    val code: Int,
+    val body: String,
+    val duration: Long,
+)
+
+/** `POST /rest/mock` 요청 바디. create-or-update 로 mock 을 설정한다. */
+data class MockRequest(
+    val method: String,
+    val path: String,
+    val code: Int,
+    val body: String,
+    val duration: Long = 0L,
+)
+
+/** `GET /inject/sinks` 응답 한 항목. 등록된 sink 의 노출 정보. */
+data class Sink(
+    val id: String,
+    val name: String,
+    val presets: List<Preset>,
+)
+
+/** sink 가 제공하는 미리 정의된 주입 payload. */
+data class Preset(
+    val name: String,
+    val payload: String,
+)

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/net/ControlClient.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/net/ControlClient.kt
@@ -1,0 +1,119 @@
+package net.spooncast.openmocker.plugin.net
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+
+/**
+ * OpenMocker 제어 서버 contract 를 의존성 0 으로 호출하는 통신 레이어.
+ *
+ * HTTP 는 Java 11 [HttpClient], JSON 은 플랫폼 번들 [Gson] 만 사용한다. 모든 호출은 예외/비2xx
+ * 상태코드를 [Result] 의 실패로 흡수해, 호출부가 try/catch 없이 성공/실패만 다루게 한다.
+ *
+ * 운영 시 대상은 adb forward 로 노출된 기기 loopback 의 [DEFAULT_PORT]. 테스트는 ephemeral
+ * 포트의 stub 서버를 주입한다.
+ */
+class ControlClient(
+    private val host: String = "localhost",
+    private val port: Int = DEFAULT_PORT,
+    private val connectTimeout: Duration = Duration.ofSeconds(2),
+    private val requestTimeout: Duration = Duration.ofSeconds(5),
+    private val gson: Gson = Gson(),
+) {
+    private val client: HttpClient = HttpClient.newBuilder()
+        .connectTimeout(connectTimeout)
+        .build()
+
+    private val baseUrl: String = "http://$host:$port"
+
+    /** `GET /rest/recorded` — 기록된 항목 목록. */
+    fun getRecorded(): Result<List<RecordedEntry>> = call {
+        val res = send(newRequest("/rest/recorded").GET().build())
+        ensureSuccess(res)
+        val type = object : TypeToken<List<RecordedEntry>>() {}.type
+        gson.fromJson<List<RecordedEntry>>(res.body(), type) ?: emptyList()
+    }
+
+    /** `POST /rest/mock` — mock create-or-update. */
+    fun upsertMock(request: MockRequest): Result<Unit> = call {
+        val res = send(
+            newRequest("/rest/mock")
+                .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(request), StandardCharsets.UTF_8))
+                .header("Content-Type", "application/json")
+                .build()
+        )
+        ensureSuccess(res)
+    }
+
+    /** `DELETE /rest/mock?method=&path=` — 특정 항목의 mock 해제. */
+    fun clearMock(method: String, path: String): Result<Unit> = call {
+        val query = "method=${encode(method)}&path=${encode(path)}"
+        val res = send(newRequest("/rest/mock?$query").DELETE().build())
+        ensureSuccess(res)
+    }
+
+    /** `DELETE /rest/mock?all=true` — 전체 mock/기록 초기화. */
+    fun clearAll(): Result<Unit> = call {
+        val res = send(newRequest("/rest/mock?all=true").DELETE().build())
+        ensureSuccess(res)
+    }
+
+    /** `GET /inject/sinks` — 등록된 sink 목록. */
+    fun getSinks(): Result<List<Sink>> = call {
+        val res = send(newRequest("/inject/sinks").GET().build())
+        ensureSuccess(res)
+        val type = object : TypeToken<List<Sink>>() {}.type
+        gson.fromJson<List<Sink>>(res.body(), type) ?: emptyList()
+    }
+
+    /** `POST /inject/{id}` — raw payload 를 파싱 없이 그대로 전달. 미등록 sink 면 404 → 실패. */
+    fun inject(id: String, payload: String): Result<Unit> = call {
+        val res = send(
+            newRequest("/inject/${encode(id)}")
+                .POST(HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8))
+                .build()
+        )
+        ensureSuccess(res)
+    }
+
+    private fun newRequest(pathAndQuery: String): HttpRequest.Builder =
+        HttpRequest.newBuilder()
+            .uri(URI.create(baseUrl + pathAndQuery))
+            .timeout(requestTimeout)
+
+    private fun send(request: HttpRequest): HttpResponse<String> =
+        client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8))
+
+    private fun ensureSuccess(res: HttpResponse<String>) {
+        if (res.statusCode() !in 200..299) {
+            throw ControlClientException(res.statusCode(), res.body())
+        }
+    }
+
+    private fun encode(value: String): String =
+        URLEncoder.encode(value, StandardCharsets.UTF_8)
+
+    /** 블록을 실행하고 던져진 예외를 [Result.failure] 로 흡수한다. */
+    private inline fun <T> call(block: () -> T): Result<T> =
+        try {
+            Result.success(block())
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+
+    companion object {
+        const val DEFAULT_PORT = 8099
+    }
+}
+
+/** 제어 서버가 비2xx 상태를 반환했을 때의 실패 사유. */
+class ControlClientException(
+    val statusCode: Int,
+    val responseBody: String,
+) : RuntimeException("control server returned $statusCode: $responseBody")

--- a/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/net/ControlClientTest.kt
+++ b/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/net/ControlClientTest.kt
@@ -1,0 +1,223 @@
+package net.spooncast.openmocker.plugin.net
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpHandler
+import com.sun.net.httpserver.HttpServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.net.InetSocketAddress
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+/**
+ * [ControlClient] 의 5 종 라우트 round-trip 과 에러 경로를, JDK 내장 [HttpServer] stub 상대로 검증.
+ * 외부 의존성 없이 ephemeral 포트에 stub 을 띄워 contract 와이어 형태를 그대로 주고받는다.
+ */
+class ControlClientTest {
+
+    private lateinit var server: HttpServer
+    private lateinit var client: ControlClient
+
+    /** 마지막으로 stub 이 수신한 요청. 라우트별 핸들러가 갱신한다. */
+    private data class CapturedRequest(
+        val method: String,
+        val path: String,
+        val rawQuery: String?,
+        val body: String,
+    )
+
+    private val captured = HashMap<String, CapturedRequest>()
+
+    @Before
+    fun setUp() {
+        server = HttpServer.create(InetSocketAddress("localhost", 0), 0)
+        server.start()
+        client = ControlClient(host = "localhost", port = server.address.port)
+    }
+
+    @After
+    fun tearDown() {
+        server.stop(0)
+    }
+
+    /** 지정 경로에 (status, body) 를 응답하고 수신 요청을 [captured] 에 기록하는 핸들러를 등록한다. */
+    private fun stub(path: String, status: Int, responseBody: String) {
+        server.createContext(path, RecordingHandler(path, status, responseBody))
+    }
+
+    private inner class RecordingHandler(
+        private val key: String,
+        private val status: Int,
+        private val responseBody: String,
+    ) : HttpHandler {
+        override fun handle(exchange: HttpExchange) {
+            val body = exchange.requestBody.readBytes().toString(StandardCharsets.UTF_8)
+            captured[key] = CapturedRequest(
+                method = exchange.requestMethod,
+                path = exchange.requestURI.path,
+                rawQuery = exchange.requestURI.rawQuery,
+                body = body,
+            )
+            val bytes = responseBody.toByteArray(StandardCharsets.UTF_8)
+            exchange.sendResponseHeaders(status, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+    }
+
+    private fun decode(value: String): String = URLDecoder.decode(value, StandardCharsets.UTF_8)
+
+    @Test
+    fun `getRecorded parses entries with and without mock`() {
+        val json = """
+            [
+              {"method":"GET","path":"/weather","response":{"code":200,"body":"sunny"},
+               "mock":{"code":500,"body":"err","duration":1000}},
+              {"method":"POST","path":"/login","response":{"code":201,"body":"ok"}}
+            ]
+        """.trimIndent()
+        stub("/rest/recorded", 200, json)
+
+        val result = client.getRecorded()
+
+        assertTrue(result.isSuccess)
+        val entries = result.getOrThrow()
+        assertEquals(2, entries.size)
+        assertEquals("GET", captured["/rest/recorded"]?.method)
+        // 첫 항목: mock 동반
+        val first = entries[0]
+        assertEquals("/weather", first.path)
+        assertEquals(200, first.response.code)
+        assertEquals("sunny", first.response.body)
+        assertNotNull(first.mock)
+        assertEquals(500, first.mock?.code)
+        assertEquals(1000L, first.mock?.duration)
+        // 둘째 항목: mock 부재 → null
+        assertNull(entries[1].mock)
+        assertEquals("/login", entries[1].path)
+    }
+
+    @Test
+    fun `upsertMock sends MockRequest as json body`() {
+        stub("/rest/mock", 200, """{"ok":true}""")
+
+        val result = client.upsertMock(
+            MockRequest(method = "GET", path = "/weather", code = 503, body = "down", duration = 250L)
+        )
+
+        assertTrue(result.isSuccess)
+        val req = captured["/rest/mock"]!!
+        assertEquals("POST", req.method)
+        // 와이어 바디는 contract 필드명을 그대로 가진 JSON
+        val sent = com.google.gson.Gson().fromJson(req.body, MockRequest::class.java)
+        assertEquals("GET", sent.method)
+        assertEquals("/weather", sent.path)
+        assertEquals(503, sent.code)
+        assertEquals("down", sent.body)
+        assertEquals(250L, sent.duration)
+    }
+
+    @Test
+    fun `clearMock sends DELETE with url-encoded method and path query`() {
+        stub("/rest/mock", 200, """{"ok":true}""")
+
+        val result = client.clearMock(method = "GET", path = "/a b/weather")
+
+        assertTrue(result.isSuccess)
+        val req = captured["/rest/mock"]!!
+        assertEquals("DELETE", req.method)
+        val query = req.rawQuery!!.split("&").associate {
+            val (k, v) = it.split("=", limit = 2)
+            decode(k) to decode(v)
+        }
+        assertEquals("GET", query["method"])
+        assertEquals("/a b/weather", query["path"])
+    }
+
+    @Test
+    fun `clearAll sends DELETE with all=true`() {
+        stub("/rest/mock", 200, """{"ok":true}""")
+
+        val result = client.clearAll()
+
+        assertTrue(result.isSuccess)
+        val req = captured["/rest/mock"]!!
+        assertEquals("DELETE", req.method)
+        assertEquals("all=true", req.rawQuery)
+    }
+
+    @Test
+    fun `getSinks parses sinks with presets`() {
+        val json = """
+            [{"id":"demo","name":"Demo Sink","presets":[
+               {"name":"p1","payload":"{\"a\":1}"},
+               {"name":"p2","payload":"raw"}]}]
+        """.trimIndent()
+        stub("/inject/sinks", 200, json)
+
+        val result = client.getSinks()
+
+        assertTrue(result.isSuccess)
+        val sinks = result.getOrThrow()
+        assertEquals(1, sinks.size)
+        assertEquals("demo", sinks[0].id)
+        assertEquals("Demo Sink", sinks[0].name)
+        assertEquals(2, sinks[0].presets.size)
+        assertEquals("p1", sinks[0].presets[0].name)
+        assertEquals("""{"a":1}""", sinks[0].presets[0].payload)
+        assertEquals("GET", captured["/inject/sinks"]?.method)
+    }
+
+    @Test
+    fun `inject posts raw payload unchanged to sink id`() {
+        // /inject/sinks 보다 짧은 prefix 컨텍스트 — HttpServer 는 최장 prefix 매칭이므로 분리됨
+        stub("/inject/", 200, """{"ok":true}""")
+
+        val raw = """{"temp":-5,"unit":"C"}"""
+        val result = client.inject(id = "demo", payload = raw)
+
+        assertTrue(result.isSuccess)
+        val req = captured["/inject/"]!!
+        assertEquals("POST", req.method)
+        assertEquals("/inject/demo", req.path)
+        // body 는 파싱·재직렬화 없이 그대로 전달되어야 한다
+        assertEquals(raw, req.body)
+    }
+
+    @Test
+    fun `non-2xx status becomes failure with ControlClientException`() {
+        stub("/inject/", 404, """{"ok":false,"error":"unknown sink: ghost"}""")
+
+        val result = client.inject(id = "ghost", payload = "{}")
+
+        assertTrue(result.isFailure)
+        val ex = result.exceptionOrNull()
+        assertTrue(ex is ControlClientException)
+        assertEquals(404, (ex as ControlClientException).statusCode)
+        assertTrue(ex.responseBody.contains("unknown sink"))
+    }
+
+    @Test
+    fun `connection failure becomes failure result`() {
+        // 서버가 떠 있지 않은 포트로 향하는 클라이언트
+        val deadClient = ControlClient(host = "localhost", port = findFreePort())
+
+        val result = deadClient.getRecorded()
+
+        assertTrue(result.isFailure)
+        assertFalse(result.exceptionOrNull() is ControlClientException) // 연결 자체 실패(IOException 계열)
+    }
+
+    /** 사용 직후 닫아 비어 있는(연결 거부될) 포트를 얻는다. */
+    private fun findFreePort(): Int {
+        val tmp = HttpServer.create(InetSocketAddress("localhost", 0), 0)
+        val port = tmp.address.port
+        tmp.stop(0)
+        return port
+    }
+}


### PR DESCRIPTION
## Meta

PR Type: feature

Closes #125

## 문제/신규 기능 설명

M2(데스크톱 제어 플러그인) 두 번째 단계로, 플러그인이 OpenMocker **제어 서버 contract 를 호출하는 통신 레이어**를 추가한다. T10(#124, plugin 골격) 위에, HTTP=Java 11 `HttpClient` / JSON=플랫폼 번들 Gson 만으로 5종 라우트를 호출한다. UI 배선(REST/WS 패널)은 후속 task(T14~)에서 이 레이어를 소비한다.

## 적용 버전

해당 없음 — `:lib`/`:app` 미변경. `plugin/` 모듈 내부 추가만(`openmocker-plugin` 0.1.0).

## 원인

신규 기능 — 해당 없음

## 수정/구현

- **`net/ContractDtos.kt`** — `:lib` 의 `control/dto/ControlDtos.kt` 와 동일한 와이어 형태를 미러한 6종 data class: `RecordedEntry`/`ResponseData`/`MockData`/`MockRequest`/`Sink`/`Preset`. 플러그인은 kotlinx.serialization 대신 Gson 을 쓰므로 **필드명을 contract 와 1:1 일치**시켜 호환(`mock` 은 nullable). 서버는 `encodeDefaults=true`·`ignoreUnknownKeys=true`.
- **`net/ControlClient.kt`** — Java 11 `HttpClient` 기반 5종 메서드, 전부 `Result<T>` 반환:
  - `getRecorded()` → `GET /rest/recorded`
  - `upsertMock(MockRequest)` → `POST /rest/mock`
  - `clearMock(method,path)` → `DELETE /rest/mock?method=&path=` (query URL-encode)
  - `clearAll()` → `DELETE /rest/mock?all=true`
  - `getSinks()` → `GET /inject/sinks`
  - `inject(id, payload)` → `POST /inject/{id}` (raw body 파싱 없이 통째 전달)
  - 공통: connect/request 타임아웃, **비2xx → `ControlClientException`**, 예외 → `Result.failure` 흡수.
- **외부 런타임 의존성 0 유지** — HttpClient(JDK) + Gson(플랫폼 번들)만 사용.

### 검증

- `cd plugin && ./gradlew test` → **8/8 통과** (skipped/failures/errors 0).
- `net/ControlClientTest.kt`: JDK 내장 `com.sun.net.httpserver.HttpServer` stub(ephemeral 포트) 상대로
  - 5종 라우트 round-trip(요청 method/path/query/body + 응답 파싱 검증),
  - `mock` 동반/부재 항목 파싱, raw payload 무변형 전달, URL-encode 쿼리 round-trip,
  - 에러경로: 비2xx → `ControlClientException(statusCode)`, 연결 실패 → 비-ControlClientException failure.

### 참고

- 운영 시 대상은 adb forward 로 노출된 기기 loopback 의 `DEFAULT_PORT=8099`. 테스트는 ephemeral 포트 주입.
- 베이스는 `release/0.1.0` — :lib control 패키지·T10 plugin 골격(#124)이 모두 이 브랜치에 모이는 0.1.0 통합 라인. (T10·#124 는 본 작업 중 release/0.1.0 로 재이관됨.)
- 상위: #114 [M2], 의존: #124 T10.

## 변경 없음

루트 `settings.gradle.kts`, `:lib`/`:app` 소스·빌드, `plugin/` 빌드 설정·`plugin.xml`·기존 ToolWindow 팩토리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)