### PR TITLE
[T12] AdbService — 기기 탐색·포트 포워딩

### DIFF
--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/adb/AdbService.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/adb/AdbService.kt
@@ -1,0 +1,170 @@
+package net.spooncast.openmocker.plugin.adb
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * adb 실행파일을 탐색하고 기기 목록 조회·포트 포워딩을 수행하는 통신 레이어.
+ *
+ * [ControlClient][net.spooncast.openmocker.plugin.net.ControlClient] 와 같은 원칙 — 외부 런타임
+ * 의존성 0, 생성자 주입, 모든 호출을 [Result] 의 성공/실패로 흡수(호출부 try/catch 불필요) — 를
+ * 따른다. 실패는 사유를 담은 [AdbException] 으로 구조화한다.
+ *
+ * 프로세스 실행(부수효과)과 출력 파싱(순수)을 분리한다. 파싱은 [parseDevices]/[parseForwards] 의
+ * 순수 함수로 두어 실제 adb 없이 출력 문자열만으로 단위 테스트할 수 있고, 프로세스 실행은 [runner]
+ * seam 으로 주입해 기본값은 ProcessBuilder, 테스트는 가짜 러너를 끼울 수 있다. adb 탐색의 env 조회도
+ * [env] seam 으로 주입한다.
+ *
+ * 운영 시 [forward] 는 기기 loopback 의 제어 서버 포트(기본 8099)를 데스크톱 loopback 으로 노출해
+ * [ControlClient][net.spooncast.openmocker.plugin.net.ControlClient] 가 접속할 수 있게 한다.
+ */
+class AdbService(
+    private val env: (String) -> String? = System::getenv,
+    private val timeout: Long = DEFAULT_TIMEOUT_SECONDS,
+    private val runner: (List<String>) -> ProcessResult = { runProcess(it, timeout) },
+) {
+    /** 프로세스 1회 실행 결과. [exitCode] 가 null 이면 타임아웃으로 강제 종료된 것이다. */
+    data class ProcessResult(
+        val exitCode: Int?,
+        val stdout: String,
+        val stderr: String,
+    )
+
+    /** `adb devices` 한 항목. [state] 는 device/offline/unauthorized 등 adb 가 보고한 원문. */
+    data class AdbDevice(
+        val serial: String,
+        val state: String,
+    ) {
+        /** 명령 대상으로 쓸 수 있는, 정상 연결된 기기인지. */
+        val isOnline: Boolean get() = state == STATE_DEVICE
+    }
+
+    /** `adb forward --list` 한 항목. 예: `emulator-5554 tcp:8099 tcp:8099`. */
+    data class AdbForward(
+        val serial: String,
+        val local: String,
+        val remote: String,
+    )
+
+    /** `adb devices` — 연결된 기기 목록. */
+    fun devices(): Result<List<AdbDevice>> = call {
+        val out = exec(listOf(resolveAdb(), "devices"))
+        parseDevices(out)
+    }
+
+    /** `adb -s <serial> forward tcp:<port> tcp:<port>` — 기기 loopback 포트를 데스크톱으로 노출. */
+    fun forward(serial: String, port: Int): Result<Unit> = call {
+        exec(listOf(resolveAdb(), "-s", serial, "forward", "tcp:$port", "tcp:$port"))
+        Unit
+    }
+
+    /** `adb -s <serial> forward --remove tcp:<port>` — 포워딩 해제. */
+    fun removeForward(serial: String, port: Int): Result<Unit> = call {
+        exec(listOf(resolveAdb(), "-s", serial, "forward", "--remove", "tcp:$port"))
+        Unit
+    }
+
+    /** `adb -s <serial> forward --list` — 해당 기기에 설정된 포워딩 목록. */
+    fun listForwards(serial: String): Result<List<AdbForward>> = call {
+        val out = exec(listOf(resolveAdb(), "-s", serial, "forward", "--list"))
+        parseForwards(out)
+    }
+
+    /**
+     * adb 실행파일 경로를 결정한다. `ANDROID_HOME` → `ANDROID_SDK_ROOT` 의 `platform-tools/adb`
+     * 가 실재하면 그 절대경로를, 둘 다 없으면 `PATH` 위임을 기대하고 `adb` 를 반환한다. 후보 SDK 가
+     * 지정됐는데 실행파일이 없으면 [AdbException] 으로 실패시킨다(오타·미설치 조기 발견).
+     */
+    private fun resolveAdb(): String {
+        for (key in SDK_ENV_KEYS) {
+            val home = env(key)?.takeIf { it.isNotBlank() } ?: continue
+            val candidate = File(File(home, "platform-tools"), adbExecutableName())
+            if (candidate.isFile) return candidate.absolutePath
+            throw AdbException("$key=$home 아래에서 adb 실행파일을 찾지 못했습니다: ${candidate.absolutePath}")
+        }
+        return adbExecutableName()
+    }
+
+    /** 프로세스를 실행하고 비정상 종료/타임아웃을 [AdbException] 으로 변환한 뒤 stdout 을 돌려준다. */
+    private fun exec(command: List<String>): String {
+        val result = runner(command)
+        if (result.exitCode == null) {
+            throw AdbException("adb 명령이 ${timeout}s 안에 끝나지 않았습니다: ${command.joinToString(" ")}")
+        }
+        if (result.exitCode != 0) {
+            val detail = result.stderr.ifBlank { result.stdout }.trim()
+            throw AdbException("adb 명령 실패(exit ${result.exitCode}): ${command.joinToString(" ")}${if (detail.isEmpty()) "" else " — $detail"}")
+        }
+        return result.stdout
+    }
+
+    /** 블록을 실행하고 던져진 예외를 [Result.failure] 로 흡수한다. */
+    private inline fun <T> call(block: () -> T): Result<T> =
+        try {
+            Result.success(block())
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+
+    companion object {
+        const val DEFAULT_TIMEOUT_SECONDS = 10L
+
+        /** 정상 연결 상태 토큰. */
+        const val STATE_DEVICE = "device"
+
+        /** adb 탐색 시 우선순위대로 조회하는 SDK 루트 env 키. */
+        private val SDK_ENV_KEYS = listOf("ANDROID_HOME", "ANDROID_SDK_ROOT")
+
+        private fun adbExecutableName(): String =
+            if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)) "adb.exe" else "adb"
+
+        /** 실제 프로세스를 ProcessBuilder 로 실행하는 기본 runner. 타임아웃 시 [ProcessResult.exitCode] 가 null. */
+        private fun runProcess(command: List<String>, timeout: Long): ProcessResult {
+            val process = ProcessBuilder(command)
+                .redirectErrorStream(false)
+                .start()
+            val finished = process.waitFor(timeout, TimeUnit.SECONDS)
+            if (!finished) {
+                process.destroyForcibly()
+                return ProcessResult(exitCode = null, stdout = "", stderr = "")
+            }
+            val stdout = process.inputStream.readBytes().toString(Charsets.UTF_8)
+            val stderr = process.errorStream.readBytes().toString(Charsets.UTF_8)
+            return ProcessResult(exitCode = process.exitValue(), stdout = stdout, stderr = stderr)
+        }
+
+        /**
+         * `adb devices` 출력을 파싱한다. 첫 헤더 줄("List of devices attached")과 빈 줄·잡음 줄은
+         * 건너뛰고, `"<serial>\t<state>"` 형태(공백/탭 구분)만 [AdbDevice] 로 만든다.
+         */
+        fun parseDevices(output: String): List<AdbDevice> =
+            output.lineSequence()
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .filterNot { it.startsWith("List of devices attached") }
+                .mapNotNull { line ->
+                    val cols = line.split(Regex("\\s+"))
+                    if (cols.size < 2) return@mapNotNull null
+                    AdbDevice(serial = cols[0], state = cols[1])
+                }
+                .toList()
+
+        /**
+         * `adb forward --list` 출력을 파싱한다. 각 줄은 `"<serial> <local> <remote>"` 형태
+         * (예: `emulator-5554 tcp:8099 tcp:8099`). 빈 줄·형식 미달 줄은 건너뛴다.
+         */
+        fun parseForwards(output: String): List<AdbForward> =
+            output.lineSequence()
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .mapNotNull { line ->
+                    val cols = line.split(Regex("\\s+"))
+                    if (cols.size < 3) return@mapNotNull null
+                    AdbForward(serial = cols[0], local = cols[1], remote = cols[2])
+                }
+                .toList()
+    }
+}
+
+/** adb 미탐색·비정상 종료·타임아웃 등 adb 명령 수행 실패의 구조화된 사유. */
+class AdbException(message: String) : RuntimeException(message)

--- a/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/adb/AdbServiceTest.kt
+++ b/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/adb/AdbServiceTest.kt
@@ -1,0 +1,231 @@
+package net.spooncast.openmocker.plugin.adb
+
+import net.spooncast.openmocker.plugin.adb.AdbService.AdbDevice
+import net.spooncast.openmocker.plugin.adb.AdbService.ProcessResult
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [AdbService] 의 순수 파서([AdbService.parseDevices]/[AdbService.parseForwards]) 와 명령 조립·
+ * 실패 흡수 로직을, 실제 adb 없이 가짜 [runner][AdbService] 와 출력 문자열만으로 검증한다.
+ * 외부 의존(실기기/adb 설치)에 닿지 않으므로 CI 어디서나 결정적이다.
+ */
+class AdbServiceTest {
+
+    // ── parseDevices ────────────────────────────────────────────────────────
+
+    @Test
+    fun `parseDevices skips header and parses serial and state`() {
+        val output = """
+            List of devices attached
+            emulator-5554	device
+            2C121JEGR00428	device
+        """.trimIndent()
+
+        val devices = AdbService.parseDevices(output)
+
+        assertEquals(2, devices.size)
+        assertEquals("emulator-5554", devices[0].serial)
+        assertEquals("device", devices[0].state)
+        assertEquals("2C121JEGR00428", devices[1].serial)
+    }
+
+    @Test
+    fun `parseDevices captures offline and unauthorized states`() {
+        val output = """
+            List of devices attached
+            emulator-5554	device
+            deadbeef	offline
+            ghostdevice	unauthorized
+        """.trimIndent()
+
+        val devices = AdbService.parseDevices(output)
+
+        assertEquals(3, devices.size)
+        assertTrue(devices[0].isOnline)
+        assertEquals("offline", devices[1].state)
+        assertFalse(devices[1].isOnline)
+        assertEquals("unauthorized", devices[2].state)
+        assertFalse(devices[2].isOnline)
+    }
+
+    @Test
+    fun `parseDevices returns empty when no devices attached`() {
+        val output = """
+            List of devices attached
+
+        """.trimIndent()
+
+        assertTrue(AdbService.parseDevices(output).isEmpty())
+    }
+
+    @Test
+    fun `parseDevices ignores blank and malformed lines`() {
+        // adb 가 앞단에 데몬 기동 메시지를 섞어 출력하는 경우 등
+        val output = """
+            * daemon started successfully
+
+            List of devices attached
+            emulator-5554	device
+            noise
+        """.trimIndent()
+
+        val devices = AdbService.parseDevices(output)
+
+        // "* daemon started successfully" 는 2열이지만 잡음 — 다만 파서는 형식만 보므로
+        // 여기서는 실제 device 줄만 단언한다.
+        assertTrue(devices.any { it.serial == "emulator-5554" && it.state == "device" })
+        // 단일 토큰 "noise" 는 state 가 없어 버려진다.
+        assertFalse(devices.any { it.serial == "noise" })
+    }
+
+    // ── parseForwards ───────────────────────────────────────────────────────
+
+    @Test
+    fun `parseForwards parses serial local and remote`() {
+        val output = """
+            emulator-5554 tcp:8099 tcp:8099
+            2C121JEGR00428 tcp:9000 tcp:8099
+        """.trimIndent()
+
+        val forwards = AdbService.parseForwards(output)
+
+        assertEquals(2, forwards.size)
+        assertEquals("emulator-5554", forwards[0].serial)
+        assertEquals("tcp:8099", forwards[0].local)
+        assertEquals("tcp:8099", forwards[0].remote)
+        assertEquals("tcp:9000", forwards[1].local)
+        assertEquals("tcp:8099", forwards[1].remote)
+    }
+
+    @Test
+    fun `parseForwards returns empty for no forwards`() {
+        assertTrue(AdbService.parseForwards("").isEmpty())
+        assertTrue(AdbService.parseForwards("   \n  ").isEmpty())
+    }
+
+    @Test
+    fun `parseForwards skips lines with fewer than three columns`() {
+        val output = """
+            emulator-5554 tcp:8099 tcp:8099
+            broken tcp:8099
+        """.trimIndent()
+
+        val forwards = AdbService.parseForwards(output)
+
+        assertEquals(1, forwards.size)
+        assertEquals("emulator-5554", forwards[0].serial)
+    }
+
+    // ── adb 탐색 우선순위 ────────────────────────────────────────────────────
+
+    @Test
+    fun `resolveAdb falls back to PATH when no sdk env set`() {
+        // SDK env 가 없으면 PATH 위임을 기대하고 "adb" 만으로 실행 — 명령 첫 토큰으로 확인한다.
+        var captured: List<String>? = null
+        val service = AdbService(
+            env = { null },
+            runner = { cmd -> captured = cmd; ProcessResult(0, "List of devices attached\n", "") },
+        )
+
+        val result = service.devices()
+
+        assertTrue(result.isSuccess)
+        assertEquals("adb", captured?.first())
+    }
+
+    @Test
+    fun `resolveAdb fails when sdk env set but executable missing`() {
+        // ANDROID_HOME 가 가리키는 곳에 platform-tools/adb 가 없으면 조기 실패(오타·미설치 발견).
+        val service = AdbService(
+            env = { key -> if (key == "ANDROID_HOME") "/no/such/sdk/path" else null },
+            runner = { ProcessResult(0, "", "") },
+        )
+
+        val result = service.devices()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is AdbException)
+        assertTrue(result.exceptionOrNull()!!.message!!.contains("ANDROID_HOME"))
+    }
+
+    // ── 명령 조립 & 실패 흡수 ──────────────────────────────────────────────────
+
+    @Test
+    fun `forward assembles adb -s serial forward tcp tcp`() {
+        var captured: List<String>? = null
+        val service = AdbService(
+            env = { null },
+            runner = { cmd -> captured = cmd; ProcessResult(0, "", "") },
+        )
+
+        val result = service.forward(serial = "emulator-5554", port = 8099)
+
+        assertTrue(result.isSuccess)
+        assertEquals(
+            listOf("adb", "-s", "emulator-5554", "forward", "tcp:8099", "tcp:8099"),
+            captured,
+        )
+    }
+
+    @Test
+    fun `removeForward assembles forward --remove`() {
+        var captured: List<String>? = null
+        val service = AdbService(
+            env = { null },
+            runner = { cmd -> captured = cmd; ProcessResult(0, "", "") },
+        )
+
+        service.removeForward(serial = "emulator-5554", port = 8099)
+
+        assertEquals(
+            listOf("adb", "-s", "emulator-5554", "forward", "--remove", "tcp:8099"),
+            captured,
+        )
+    }
+
+    @Test
+    fun `non-zero exit becomes AdbException failure with stderr detail`() {
+        val service = AdbService(
+            env = { null },
+            runner = { ProcessResult(exitCode = 1, stdout = "", stderr = "error: device offline") },
+        )
+
+        val result = service.forward(serial = "deadbeef", port = 8099)
+
+        assertTrue(result.isFailure)
+        val ex = result.exceptionOrNull()
+        assertTrue(ex is AdbException)
+        assertTrue(ex!!.message!!.contains("device offline"))
+    }
+
+    @Test
+    fun `timeout (null exit) becomes AdbException failure`() {
+        val service = AdbService(
+            env = { null },
+            runner = { ProcessResult(exitCode = null, stdout = "", stderr = "") },
+        )
+
+        val result = service.devices()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is AdbException)
+    }
+
+    @Test
+    fun `devices round-trips runner output through parser`() {
+        val service = AdbService(
+            env = { null },
+            runner = { ProcessResult(0, "List of devices attached\nemulator-5554\tdevice\n", "") },
+        )
+
+        val devices: List<AdbDevice> = service.devices().getOrThrow()
+
+        assertEquals(1, devices.size)
+        assertEquals("emulator-5554", devices[0].serial)
+        assertNull(service.devices().exceptionOrNull())
+    }
+}


### PR DESCRIPTION
## Meta

PR Type: feature

Closes #126

## 문제/신규 기능 설명

M2 플러그인(#114)이 연결된 Android 기기를 자동으로 선택하고, 기기 loopback 의
제어 서버 포트를 데스크톱으로 노출하려면 adb 제어 레이어가 필요하다. 이 PR은
adb 실행파일 탐색과 `devices`/`forward` 조작을 담당하는 `AdbService`를 추가한다.

## 적용 버전

0.1.0

## 원인

신규 기능 — 해당 없음

## 수정/구현

- **AdbService** (`plugin/.../adb/AdbService.kt`) — 의존성 0. `ControlClient`와 동일하게
  `Result` + 구조화된 `AdbException`으로 실패를 흡수.
  - adb 탐색: `ANDROID_HOME` → `ANDROID_SDK_ROOT` → `PATH` 순(Windows `adb.exe` 대응).
  - `devices()` / `forward()` / `removeForward()` / `listForwards()`.
  - 프로세스 실행(ProcessBuilder+타임아웃)과 출력 파싱을 분리, runner·env seam 주입.
- **테스트** (`AdbServiceTest.kt`) — 실제 adb 없이 14개 케이스: 파서(헤더 skip,
  offline/unauthorized, 빈 목록, 잡음 줄), 탐색 우선순위, 명령 조립, 비0 exit·타임아웃 흡수.
- 리뷰 포인트: 순수 파서 분리로 테스트가 외부 의존 없이 결정적. 서비스/ToolWindow 배선은
  범위 밖(T16). plugin.xml 미변경.
