### PR TITLE
플러그인 설정 영속화

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -24,6 +24,10 @@ dependencies {
         create(IntelliJPlatformType.IntellijIdeaCommunity, "2024.2.5")
         testFramework(TestFrameworkType.Platform)
     }
+
+    // BasePlatformTestCase(플랫폼 컨테이너 부팅 테스트)의 단언이 opentest4j 를 요구하나 플랫폼이
+    // 런타임 제공하지 않아 명시한다. 테스트 전용 — 플러그인 런타임 의존성 0 원칙엔 영향 없다.
+    testRuntimeOnly("org.opentest4j:opentest4j:1.3.0")
 }
 
 intellijPlatform {

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/settings/MockerConfigurable.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/settings/MockerConfigurable.kt
@@ -1,0 +1,61 @@
+package net.spooncast.openmocker.plugin.settings
+
+import com.intellij.openapi.options.BoundConfigurable
+import com.intellij.openapi.options.ConfigurationException
+import com.intellij.openapi.ui.DialogPanel
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.dsl.builder.bindIntText
+import com.intellij.ui.dsl.builder.bindSelected
+import com.intellij.ui.dsl.builder.panel
+
+/**
+ * Settings/Preferences > Tools > OpenMocker 화면. [MockerSettings] 값을 노출·편집한다.
+ *
+ * UI 는 플랫폼 번들 Kotlin UI DSL 만 쓴다(외부 의존성 0 원칙). 각 입력은 [MockerSettings.state] 의
+ * 필드에 직접 바인딩되므로, DSL 이 reset/isModified/apply 를 자동 처리한다. 값의 유효 범위만
+ * [apply] 에서 추가 검증해 잘못된 포트·과도하게 짧은 폴링 주기를 막는다.
+ *
+ * `lastDeviceSerial` 은 사용자가 직접 입력하는 값이 아니라 기기 드롭다운이 갱신하는 값이라 이 화면엔
+ * 노출하지 않는다.
+ */
+class MockerConfigurable : BoundConfigurable("OpenMocker") {
+
+    private val state get() = MockerSettings.getInstance().state
+
+    override fun createPanel(): DialogPanel = panel {
+        row("Control server port:") {
+            intTextField(range = MIN_PORT..MAX_PORT)
+                .bindIntText(state::port)
+                .comment("기기 loopback 에서 OpenMocker 제어 서버가 바인딩된 포트 (기본 ${MockerSettings.DEFAULT_PORT}).")
+        }
+        row("Poll interval (ms):") {
+            intTextField(range = MIN_POLL_INTERVAL_MS..MAX_POLL_INTERVAL_MS)
+                .bindIntText(state::pollIntervalMs)
+                .comment("REST 기록 테이블을 새로고침하는 주기 (기본 ${MockerSettings.DEFAULT_POLL_INTERVAL_MS}ms).")
+        }
+        row {
+            cell(JBCheckBox("기기 선택 시 자동으로 adb forward 설정"))
+                .bindSelected(state::autoForward)
+        }
+    }
+
+    /** DSL 바인딩을 state 에 반영하기 전에 값의 유효 범위를 검증한다. */
+    @Throws(ConfigurationException::class)
+    override fun apply() {
+        super.apply()
+        val current = state
+        if (current.port !in MIN_PORT..MAX_PORT) {
+            throw ConfigurationException("포트는 $MIN_PORT~$MAX_PORT 범위여야 합니다.")
+        }
+        if (current.pollIntervalMs < MIN_POLL_INTERVAL_MS) {
+            throw ConfigurationException("폴링 주기는 최소 ${MIN_POLL_INTERVAL_MS}ms 이상이어야 합니다.")
+        }
+    }
+
+    private companion object {
+        const val MIN_PORT = 1
+        const val MAX_PORT = 65535
+        const val MIN_POLL_INTERVAL_MS = 250
+        const val MAX_POLL_INTERVAL_MS = 60_000
+    }
+}

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/settings/MockerSettings.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/settings/MockerSettings.kt
@@ -1,0 +1,61 @@
+package net.spooncast.openmocker.plugin.settings
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.util.xmlb.XmlSerializerUtil
+
+/**
+ * 플러그인 제어에 필요한 사용자 설정을 IDE 재시작 후에도 유지하는 application-level 영속화 서비스.
+ *
+ * [ControlClient][net.spooncast.openmocker.plugin.net.ControlClient] ·
+ * [AdbService][net.spooncast.openmocker.plugin.adb.AdbService] 와 같은 원칙(외부 런타임 의존성 0)을
+ * 따른다. 영속화는 IntelliJ Platform 표준 [PersistentStateComponent] 로만 처리하며, 직렬화 대상은
+ * 공개 var 만 가진 단순 [State] 데이터 클래스다. `@Service` 로 등록되므로 plugin.xml 에 별도 선언이
+ * 필요 없다.
+ *
+ * 포트·폴링 주기·자동 forward 는 프로젝트와 무관한 전역 설정이라 app-level(`openmocker.xml`)에 둔다.
+ * 마지막 선택 기기 serial 도 같은 저장소에 보관해, 다음 세션에서 동일 기기를 기본 선택할 수 있게 한다
+ * (드롭다운 연동·forward 트리거는 후속 task 의 책임이고, 여기서는 값만 보관한다).
+ */
+@Service(Service.Level.APP)
+@State(name = "OpenMockerSettings", storages = [Storage("openmocker.xml")])
+class MockerSettings : PersistentStateComponent<MockerSettings.State> {
+
+    /**
+     * 직렬화되는 설정 값. XML 직렬화기가 채울 수 있도록 모든 필드를 기본값을 가진 공개 var 로 둔다.
+     *
+     * - [port]: 기기 loopback 의 제어 서버 포트(기본 [DEFAULT_PORT]). adb forward 의 대상과 일치.
+     * - [lastDeviceSerial]: 마지막으로 선택한 adb 기기 serial. 미선택 상태는 빈 문자열.
+     * - [pollIntervalMs]: REST 기록 테이블 폴링 주기(ms, 기본 [DEFAULT_POLL_INTERVAL_MS]).
+     * - [autoForward]: 기기 선택 시 자동으로 adb forward 를 설정할지 여부.
+     */
+    data class State(
+        var port: Int = DEFAULT_PORT,
+        var lastDeviceSerial: String = "",
+        var pollIntervalMs: Int = DEFAULT_POLL_INTERVAL_MS,
+        var autoForward: Boolean = true,
+    )
+
+    private var state = State()
+
+    override fun getState(): State = state
+
+    override fun loadState(state: State) {
+        XmlSerializerUtil.copyBean(state, this.state)
+    }
+
+    companion object {
+        /** 제어 서버 기본 포트. lib 측 `ControlServer.DEFAULT_PORT` 와 일치시킨다. */
+        const val DEFAULT_PORT = 8099
+
+        /** REST 기록 폴링 기본 주기(ms). */
+        const val DEFAULT_POLL_INTERVAL_MS = 1500
+
+        /** application-level 싱글턴 인스턴스를 돌려준다. */
+        fun getInstance(): MockerSettings =
+            ApplicationManager.getApplication().getService(MockerSettings::class.java)
+    }
+}

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -15,5 +15,12 @@
             id="OpenMocker"
             anchor="right"
             factoryClass="net.spooncast.openmocker.plugin.ui.MockerToolWindowFactory" />
+
+        <!-- 설정 영속화는 @Service(MockerSettings)라 무등록. Settings UI 만 등록한다. -->
+        <applicationConfigurable
+            parentId="tools"
+            id="net.spooncast.openmocker.settings"
+            displayName="OpenMocker"
+            instance="net.spooncast.openmocker.plugin.settings.MockerConfigurable" />
     </extensions>
 </idea-plugin>

--- a/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/settings/MockerSettingsPlatformTest.kt
+++ b/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/settings/MockerSettingsPlatformTest.kt
@@ -1,0 +1,64 @@
+package net.spooncast.openmocker.plugin.settings
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+/**
+ * 실제 IntelliJ Platform Application 컨테이너를 부팅해, 순수 단위 테스트가 닿지 못하는 두 지점을
+ * 런타임에서 직접 실행시켜 관찰한다:
+ *
+ *  1. [MockerSettings] 가 `@Service(APP)` 로 컨테이너에 등록돼 [MockerSettings.getInstance] 로
+ *     싱글턴이 해석되고, 그 인스턴스가 상태를 round-trip 으로 보존하는지.
+ *  2. [MockerConfigurable] 의 `createComponent()` 가 Kotlin UI DSL 패널을 예외 없이 빌드하는지
+ *     (= `applicationConfigurable` 가 Settings 화면을 열었을 때 실제로 일어나는 일).
+ *
+ * 검증 용도의 통합 테스트다 — GUI 다이얼로그를 헤드리스로 클릭할 수 없어, 동일 코드 경로를 플랫폼
+ * 컨테이너 위에서 실행해 관찰을 대신한다.
+ */
+class MockerSettingsPlatformTest : BasePlatformTestCase() {
+
+    fun testServiceResolvesAsSingletonAndRoundTrips() {
+        val settings = MockerSettings.getInstance()
+        assertNotNull("MockerSettings 가 @Service 로 해석되어야 한다", settings)
+        assertSame("getInstance 는 app-level 싱글턴이어야 한다", settings, MockerSettings.getInstance())
+
+        val original = settings.state.copy()
+        try {
+            settings.loadState(
+                MockerSettings.State(
+                    port = 9001,
+                    lastDeviceSerial = "platform-dev",
+                    pollIntervalMs = 750,
+                    autoForward = false,
+                )
+            )
+
+            val reread = MockerSettings.getInstance().state
+            assertEquals(9001, reread.port)
+            assertEquals("platform-dev", reread.lastDeviceSerial)
+            assertEquals(750, reread.pollIntervalMs)
+            assertFalse(reread.autoForward)
+        } finally {
+            settings.loadState(original) // 다른 테스트로 상태가 새지 않도록 복원
+        }
+    }
+
+    fun testConfigurableBuildsPanelAndBindsToState() {
+        val settings = MockerSettings.getInstance()
+        val original = settings.state.copy()
+        val configurable = MockerConfigurable()
+        try {
+            settings.loadState(original.copy(port = 8123, pollIntervalMs = 2000, autoForward = true))
+
+            // createComponent() 가 createPanel() 을 호출 — DSL API 오용이면 여기서 예외.
+            val component = configurable.createComponent()
+            assertNotNull("Settings 패널이 빌드되어야 한다", component)
+
+            // 패널을 state 로 채운 뒤(reset) 변경이 없으면 isModified=false 여야 바인딩이 성립한 것.
+            configurable.reset()
+            assertFalse("reset 직후엔 수정 없음이어야 한다", configurable.isModified)
+        } finally {
+            configurable.disposeUIResources()
+            settings.loadState(original)
+        }
+    }
+}

--- a/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/settings/MockerSettingsTest.kt
+++ b/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/settings/MockerSettingsTest.kt
@@ -1,0 +1,54 @@
+package net.spooncast.openmocker.plugin.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [MockerSettings] 의 기본값과 직렬화 round-trip 을 플랫폼 없이 검증한다.
+ *
+ * `@Service` 싱글턴 획득([MockerSettings.getInstance])은 application 컨텍스트를 요구하므로, 영속화
+ * 계약(`getState`/`loadState`)만 떼어 인스턴스를 직접 만들어 본다. 이 두 함수가 [State] 4 필드를
+ * 손실 없이 보존하는지가 "재시작 후에도 설정 유지"의 핵심이다.
+ */
+class MockerSettingsTest {
+
+    @Test
+    fun `defaults match documented values`() {
+        val state = MockerSettings.State()
+
+        assertEquals(MockerSettings.DEFAULT_PORT, state.port)
+        assertEquals("", state.lastDeviceSerial)
+        assertEquals(MockerSettings.DEFAULT_POLL_INTERVAL_MS, state.pollIntervalMs)
+        assertTrue(state.autoForward)
+    }
+
+    @Test
+    fun `getState returns current state`() {
+        val settings = MockerSettings()
+
+        assertEquals(MockerSettings.State(), settings.state)
+    }
+
+    @Test
+    fun `loadState round-trips all fields`() {
+        val source = MockerSettings()
+        source.loadState(
+            MockerSettings.State(
+                port = 9000,
+                lastDeviceSerial = "emulator-5554",
+                pollIntervalMs = 500,
+                autoForward = false,
+            )
+        )
+
+        // 새 인스턴스에 직전 상태를 주입했을 때 4 필드가 그대로 복원되는지(저장→로드 round-trip).
+        val restored = MockerSettings()
+        restored.loadState(source.state)
+
+        assertEquals(9000, restored.state.port)
+        assertEquals("emulator-5554", restored.state.lastDeviceSerial)
+        assertEquals(500, restored.state.pollIntervalMs)
+        assertEquals(false, restored.state.autoForward)
+    }
+}


### PR DESCRIPTION
## Meta

PR Type: feature

Closes #127

## 문제/신규 기능 설명

플러그인의 포트·폴링 주기·자동 forward·마지막 선택 기기 설정을 IDE 재시작 후에도
유지하도록 영속화하고, Settings UI로 노출한다.

## 적용 버전

0.1.0

## 원인

신규 기능 — 해당 없음

## 수정/구현

- **영속화 (`MockerSettings`)** — `@Service(APP)` + `PersistentStateComponent` 로
  `openmocker.xml` 에 저장. `State(port=8099, lastDeviceSerial, pollIntervalMs=1500,
  autoForward)`. 포트는 lib `ControlServer.DEFAULT_PORT` 와 일치.
- **Settings UI (`MockerConfigurable`)** — Settings > Tools > OpenMocker. Kotlin UI
  DSL 로 포트·폴링 주기·autoForward 바인딩, `apply()` 에서 포트·폴링 범위 검증.
  `lastDeviceSerial` 은 드롭다운이 갱신하는 값이라 미노출.
- **등록 (`plugin.xml`)** — `applicationConfigurable` 만 등록(설정 서비스는 `@Service`
  라 무등록).
- **테스트** — state round-trip 단위 테스트 + 플랫폼 부팅 테스트. `BasePlatformTestCase`
  단언이 요구하는 `opentest4j` 를 `testRuntimeOnly` 로 추가(테스트 전용, 런타임 의존성 0 원칙 유지).
- 리뷰 포인트: 외부 런타임 의존성 0 원칙 준수(플랫폼 번들 API만 사용), 검증 범위 경계.
