### PR TITLE
[T14] REST 패널

### DIFF
--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/MockerToolWindowFactory.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/MockerToolWindowFactory.kt
@@ -3,23 +3,24 @@ package net.spooncast.openmocker.plugin.ui
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
-import com.intellij.ui.components.JBLabel
-import com.intellij.ui.components.JBPanel
-import java.awt.BorderLayout
+import net.spooncast.openmocker.plugin.net.ControlClient
+import net.spooncast.openmocker.plugin.settings.MockerSettings
 
-/**
- * OpenMocker ToolWindow 의 골격 팩토리.
- *
- * 현재는 빈 placeholder 패널만 부착한다. REST 패널(T14)·WS 패널(T15)·기기 드롭다운/상태 배너는
- * 이후 task 에서 이 팩토리를 확장해 채운다.
- */
 class MockerToolWindowFactory : ToolWindowFactory {
 
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
-        val panel = JBPanel<JBPanel<*>>(BorderLayout()).apply {
-            add(JBLabel("OpenMocker", JBLabel.CENTER), BorderLayout.CENTER)
-        }
-        val content = toolWindow.contentManager.factory.createContent(panel, null, false)
+        val settings = MockerSettings.getInstance().state
+        val client = ControlClient(port = settings.port)
+        val restPanel = RestPanel(client)
+
+        val content = toolWindow.contentManager.factory.createContent(restPanel, "REST", false)
         toolWindow.contentManager.addContent(content)
+
+        toolWindow.contentManager.addContentManagerListener(object :
+            com.intellij.ui.content.ContentManagerListener {
+            override fun contentRemoved(event: com.intellij.ui.content.ContentManagerEvent) {
+                restPanel.stopPolling()
+            }
+        })
     }
 }

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RecordedTableModel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RecordedTableModel.kt
@@ -1,0 +1,36 @@
+package net.spooncast.openmocker.plugin.ui
+
+import net.spooncast.openmocker.plugin.net.RecordedEntry
+import javax.swing.table.AbstractTableModel
+
+class RecordedTableModel : AbstractTableModel() {
+
+    private val columns = arrayOf("Method", "Path", "Mocked?")
+    private var entries: List<RecordedEntry> = emptyList()
+
+    fun update(newEntries: List<RecordedEntry>) {
+        entries = newEntries
+        fireTableDataChanged()
+    }
+
+    fun getEntryAt(row: Int): RecordedEntry = entries[row]
+
+    override fun getRowCount(): Int = entries.size
+
+    override fun getColumnCount(): Int = columns.size
+
+    override fun getColumnName(column: Int): String = columns[column]
+
+    override fun getValueAt(rowIndex: Int, columnIndex: Int): Any {
+        val entry = entries[rowIndex]
+        return when (columnIndex) {
+            0 -> entry.method
+            1 -> entry.path
+            2 -> entry.mock != null
+            else -> ""
+        }
+    }
+
+    override fun getColumnClass(columnIndex: Int): Class<*> =
+        if (columnIndex == 2) Boolean::class.javaObjectType else String::class.java
+}

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RestPanel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RestPanel.kt
@@ -1,0 +1,144 @@
+package net.spooncast.openmocker.plugin.ui
+
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextArea
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.table.JBTable
+import net.spooncast.openmocker.plugin.net.ControlClient
+import net.spooncast.openmocker.plugin.net.MockRequest
+import net.spooncast.openmocker.plugin.settings.MockerSettings
+import java.awt.BorderLayout
+import java.awt.FlowLayout
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.Insets
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import javax.swing.BorderFactory
+import javax.swing.JButton
+import javax.swing.JPanel
+import javax.swing.ListSelectionModel
+import javax.swing.SwingUtilities
+
+class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
+
+    private val tableModel = RecordedTableModel()
+    private val table = JBTable(tableModel).apply {
+        selectionModel.selectionMode = ListSelectionModel.SINGLE_SELECTION
+        setShowGrid(false)
+        columnModel.getColumn(2).maxWidth = 70
+        columnModel.getColumn(2).minWidth = 70
+    }
+
+    private val codeField = JBTextField(6)
+    private val bodyArea = JBTextArea(5, 40).apply { lineWrap = true; wrapStyleWord = true }
+
+    private val saveButton = JButton("저장").apply { isEnabled = false }
+    private val clearMockButton = JButton("Mock 해제").apply { isEnabled = false }
+    private val clearAllButton = JButton("전체 Clear")
+    private val refreshButton = JButton("새로고침")
+
+    private val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { r ->
+        Thread(r, "openmocker-poll").apply { isDaemon = true }
+    }
+
+    init {
+        add(buildToolbar(), BorderLayout.NORTH)
+        add(JBScrollPane(table), BorderLayout.CENTER)
+        add(buildEditPanel(), BorderLayout.SOUTH)
+
+        wireActions()
+        startPolling()
+    }
+
+    private fun buildToolbar(): JPanel = JPanel(FlowLayout(FlowLayout.LEFT, 4, 2)).apply {
+        add(refreshButton)
+        add(clearAllButton)
+    }
+
+    private fun buildEditPanel(): JPanel = JPanel(GridBagLayout()).apply {
+        border = BorderFactory.createTitledBorder("편집")
+        val gbc = GridBagConstraints().apply {
+            insets = Insets(2, 4, 2, 4)
+            fill = GridBagConstraints.HORIZONTAL
+        }
+
+        gbc.gridx = 0; gbc.gridy = 0; gbc.weightx = 0.0
+        add(JBLabel("Status Code"), gbc)
+        gbc.gridx = 1; gbc.weightx = 0.2
+        add(codeField, gbc)
+
+        gbc.gridx = 0; gbc.gridy = 1; gbc.weightx = 0.0; gbc.fill = GridBagConstraints.NONE
+        add(JBLabel("Body"), gbc)
+        gbc.gridx = 1; gbc.weightx = 1.0; gbc.fill = GridBagConstraints.BOTH
+        add(JBScrollPane(bodyArea), gbc)
+
+        gbc.gridx = 0; gbc.gridy = 2; gbc.gridwidth = 2; gbc.fill = GridBagConstraints.NONE
+        gbc.anchor = GridBagConstraints.EAST; gbc.weightx = 0.0
+        val buttonPanel = JPanel(FlowLayout(FlowLayout.RIGHT, 4, 0)).apply {
+            add(clearMockButton)
+            add(saveButton)
+        }
+        add(buttonPanel, gbc)
+    }
+
+    private fun wireActions() {
+        table.selectionModel.addListSelectionListener { e ->
+            if (e.valueIsAdjusting) return@addListSelectionListener
+            val row = table.selectedRow
+            if (row < 0) {
+                saveButton.isEnabled = false
+                clearMockButton.isEnabled = false
+                return@addListSelectionListener
+            }
+            val entry = tableModel.getEntryAt(row)
+            codeField.text = (entry.mock?.code ?: entry.response.code).toString()
+            bodyArea.text = entry.mock?.body ?: entry.response.body
+            saveButton.isEnabled = true
+            clearMockButton.isEnabled = entry.mock != null
+        }
+
+        saveButton.addActionListener {
+            val row = table.selectedRow.takeIf { it >= 0 } ?: return@addActionListener
+            val entry = tableModel.getEntryAt(row)
+            val code = codeField.text.trim().toIntOrNull() ?: return@addActionListener
+            val body = bodyArea.text
+            client.upsertMock(MockRequest(method = entry.method, path = entry.path, code = code, body = body))
+            refresh()
+        }
+
+        clearMockButton.addActionListener {
+            val row = table.selectedRow.takeIf { it >= 0 } ?: return@addActionListener
+            val entry = tableModel.getEntryAt(row)
+            client.clearMock(method = entry.method, path = entry.path)
+            refresh()
+        }
+
+        clearAllButton.addActionListener {
+            client.clearAll()
+            refresh()
+        }
+
+        refreshButton.addActionListener { refresh() }
+    }
+
+    private fun startPolling() {
+        val intervalMs = MockerSettings.getInstance().state.pollIntervalMs.toLong()
+        scheduler.scheduleAtFixedRate(::refresh, 0L, intervalMs, TimeUnit.MILLISECONDS)
+    }
+
+    private fun refresh() {
+        val result = client.getRecorded()
+        if (result.isSuccess) {
+            SwingUtilities.invokeLater {
+                tableModel.update(result.getOrThrow())
+            }
+        }
+    }
+
+    fun stopPolling() {
+        scheduler.shutdownNow()
+    }
+}

--- a/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/ui/RecordedTableModelTest.kt
+++ b/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/ui/RecordedTableModelTest.kt
@@ -1,0 +1,91 @@
+package net.spooncast.openmocker.plugin.ui
+
+import net.spooncast.openmocker.plugin.net.MockData
+import net.spooncast.openmocker.plugin.net.RecordedEntry
+import net.spooncast.openmocker.plugin.net.ResponseData
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class RecordedTableModelTest {
+
+    private lateinit var model: RecordedTableModel
+
+    @Before
+    fun setUp() {
+        model = RecordedTableModel()
+    }
+
+    @Test
+    fun `초기 상태는 rowCount가 0`() {
+        assertEquals(0, model.rowCount)
+    }
+
+    @Test
+    fun `update 후 rowCount는 entries 수와 일치`() {
+        model.update(listOf(entry("GET", "/a"), entry("POST", "/b")))
+        assertEquals(2, model.rowCount)
+    }
+
+    @Test
+    fun `update 재호출 시 이전 데이터를 교체`() {
+        model.update(listOf(entry("GET", "/a"), entry("POST", "/b")))
+        model.update(listOf(entry("DELETE", "/c")))
+        assertEquals(1, model.rowCount)
+        assertEquals("DELETE", model.getValueAt(0, 0))
+    }
+
+    @Test
+    fun `Method 컬럼 값이 entry method 와 일치`() {
+        model.update(listOf(entry("PUT", "/x")))
+        assertEquals("PUT", model.getValueAt(0, 0))
+    }
+
+    @Test
+    fun `Path 컬럼 값이 entry path 와 일치`() {
+        model.update(listOf(entry("GET", "/weather")))
+        assertEquals("/weather", model.getValueAt(0, 1))
+    }
+
+    @Test
+    fun `mock 이 null 이면 Mocked 컬럼이 false`() {
+        model.update(listOf(entry("GET", "/a", mock = null)))
+        assertFalse(model.getValueAt(0, 2) as Boolean)
+    }
+
+    @Test
+    fun `mock 이 있으면 Mocked 컬럼이 true`() {
+        val withMock = entry("GET", "/a", mock = MockData(code = 500, body = "err", duration = 0L))
+        model.update(listOf(withMock))
+        assertTrue(model.getValueAt(0, 2) as Boolean)
+    }
+
+    @Test
+    fun `getEntryAt 은 해당 인덱스의 RecordedEntry 를 반환`() {
+        val e = entry("GET", "/check")
+        model.update(listOf(e))
+        assertEquals(e, model.getEntryAt(0))
+    }
+
+    @Test
+    fun `컬럼 수는 3`() {
+        assertEquals(3, model.columnCount)
+    }
+
+    @Test
+    fun `컬럼 이름이 Method Path Mocked 순`() {
+        assertEquals("Method", model.getColumnName(0))
+        assertEquals("Path", model.getColumnName(1))
+        assertEquals("Mocked?", model.getColumnName(2))
+    }
+
+    private fun entry(method: String, path: String, mock: MockData? = null) =
+        RecordedEntry(
+            method = method,
+            path = path,
+            response = ResponseData(code = 200, body = "ok"),
+            mock = mock,
+        )
+}


### PR DESCRIPTION
## Meta

PR Type: feature

Closes #128

## 문제/신규 기능 설명

기록된 REST 응답을 보고 mock을 편집·해제하는 핵심 ToolWindow UI를 구현한다.
플러그인의 주 기능인 "기록 테이블 조회 → mock 설정/해제"가 실제 동작하게 된다.

## 적용 버전

plugin 0.1.0

## 원인

신규 기능 — 해당 없음

## 수정/구현

| 파일 | 내용 |
|---|---|
| `RecordedTableModel` | `AbstractTableModel` — Method / Path / Mocked? 3컬럼, `update()` + `getEntryAt()` |
| `RestPanel` | JBTable + 툴바(새로고침·전체Clear) + 편집 영역(status code·body) + 저장/Mock해제 버튼 |
| `MockerToolWindowFactory` | placeholder JBLabel 제거 → `RestPanel` 배선, `stopPolling()` dispose 연결 |
| `RecordedTableModelTest` | 갱신·Mocked 표시·컬럼값 단위 테스트 10개 |

**동작 흐름:**
- ToolWindow 열릴 때 `ScheduledExecutorService`(기본 1500ms) 폴링 시작 → `getRecorded()` 호출 → EDT에서 테이블 갱신
- 행 선택 → 편집 영역에 mock(또는 원본 response) 값 채움 → 저장(`POST /rest/mock`) / Mock해제(`DELETE /rest/mock`) / 전체Clear(`DELETE /rest/mock?all=true`)
- ToolWindow content 제거 시 `stopPolling()` 호출로 폴링 스레드 종료

**리뷰 포인트:** `RestPanel` 생성자가 `ControlClient`를 주입받아 T16 세션 연결 시 교체 용이. 폴링 에러는 `Result.failure`로 흡수해 UI 차단 없음.
