### PR TITLE
[T15] WS 패널

### DIFF
--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/MockerToolWindowFactory.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/MockerToolWindowFactory.kt
@@ -12,9 +12,12 @@ class MockerToolWindowFactory : ToolWindowFactory {
         val settings = MockerSettings.getInstance().state
         val client = ControlClient(port = settings.port)
         val restPanel = RestPanel(client)
+        val wsPanel = WsPanel(client)
 
-        val content = toolWindow.contentManager.factory.createContent(restPanel, "REST", false)
-        toolWindow.contentManager.addContent(content)
+        val restContent = toolWindow.contentManager.factory.createContent(restPanel, "REST", false)
+        val wsContent = toolWindow.contentManager.factory.createContent(wsPanel, "WebSocket", false)
+        toolWindow.contentManager.addContent(restContent)
+        toolWindow.contentManager.addContent(wsContent)
 
         toolWindow.contentManager.addContentManagerListener(object :
             com.intellij.ui.content.ContentManagerListener {

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/WsPanel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/WsPanel.kt
@@ -1,0 +1,107 @@
+package net.spooncast.openmocker.plugin.ui
+
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextArea
+import net.spooncast.openmocker.plugin.net.ControlClient
+import net.spooncast.openmocker.plugin.net.Sink
+import java.awt.BorderLayout
+import java.awt.FlowLayout
+import javax.swing.JButton
+import javax.swing.JComboBox
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
+
+class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
+
+    private var sinks: List<Sink> = emptyList()
+    private val sinkCombo = JComboBox<String>()
+    private val presetsPanel = JPanel(FlowLayout(FlowLayout.LEFT, 4, 2))
+    private val payloadArea = JBTextArea(8, 40).apply { lineWrap = true; wrapStyleWord = true }
+    private val injectButton = JButton("Inject").apply { isEnabled = false }
+    private val statusLabel = JBLabel("")
+    private val refreshButton = JButton("새로고침")
+
+    init {
+        add(buildToolbar(), BorderLayout.NORTH)
+        add(buildCenterPanel(), BorderLayout.CENTER)
+        add(buildSouthPanel(), BorderLayout.SOUTH)
+        wireActions()
+        loadSinks()
+    }
+
+    private fun buildToolbar(): JPanel = JPanel(FlowLayout(FlowLayout.LEFT, 4, 2)).apply {
+        add(refreshButton)
+        add(JBLabel("Sink:"))
+        add(sinkCombo)
+    }
+
+    private fun buildCenterPanel(): JPanel = JPanel(BorderLayout()).apply {
+        add(presetsPanel, BorderLayout.NORTH)
+        add(JBScrollPane(payloadArea), BorderLayout.CENTER)
+    }
+
+    private fun buildSouthPanel(): JPanel = JPanel(FlowLayout(FlowLayout.LEFT, 4, 4)).apply {
+        add(injectButton)
+        add(statusLabel)
+    }
+
+    private fun wireActions() {
+        refreshButton.addActionListener { loadSinks() }
+
+        sinkCombo.addActionListener {
+            val idx = sinkCombo.selectedIndex
+            if (idx >= 0 && idx < sinks.size) updatePresets(sinks[idx])
+        }
+
+        injectButton.addActionListener {
+            val idx = sinkCombo.selectedIndex.takeIf { it >= 0 } ?: return@addActionListener
+            val sink = sinks.getOrNull(idx) ?: return@addActionListener
+            val payload = payloadArea.text
+            Thread {
+                val result = client.inject(sink.id, payload)
+                SwingUtilities.invokeLater {
+                    statusLabel.text = if (result.isSuccess) "● 주입 성공" else "✗ 실패: ${result.exceptionOrNull()?.message}"
+                }
+            }.apply { isDaemon = true; start() }
+        }
+    }
+
+    private fun loadSinks() {
+        statusLabel.text = "로드 중…"
+        Thread {
+            val result = client.getSinks()
+            SwingUtilities.invokeLater {
+                if (result.isSuccess) {
+                    sinks = result.getOrThrow()
+                    sinkCombo.removeAllItems()
+                    sinks.forEach { sinkCombo.addItem(it.name) }
+                    if (sinks.isNotEmpty()) {
+                        sinkCombo.selectedIndex = 0
+                        updatePresets(sinks[0])
+                        injectButton.isEnabled = true
+                    } else {
+                        presetsPanel.removeAll()
+                        presetsPanel.revalidate()
+                        presetsPanel.repaint()
+                        injectButton.isEnabled = false
+                    }
+                    statusLabel.text = if (sinks.isEmpty()) "등록된 sink 없음" else ""
+                } else {
+                    statusLabel.text = "✗ sink 로드 실패: ${result.exceptionOrNull()?.message}"
+                }
+            }
+        }.apply { isDaemon = true; start() }
+    }
+
+    private fun updatePresets(sink: Sink) {
+        presetsPanel.removeAll()
+        sink.presets.forEach { preset ->
+            presetsPanel.add(JButton(preset.name).apply {
+                addActionListener { payloadArea.text = preset.payload }
+            })
+        }
+        presetsPanel.revalidate()
+        presetsPanel.repaint()
+    }
+}


### PR DESCRIPTION
## Meta

PR Type: feature

Closes #129

## 문제/신규 기능 설명

OpenMocker 플러그인에서 WebSocket 이벤트를 GUI로 직접 발사할 수 있는 WS 패널을 추가한다.
기존에는 `curl POST /inject/{id}` 를 직접 입력해야 했던 것을, IDE 안에서 sink 선택 → 프리셋 클릭 → Inject 버튼으로 처리할 수 있게 된다.

## 적용 버전

0.1.0

## 원인

신규 기능 — 해당 없음

## 수정/구현

- **WsPanel** (`plugin/.../ui/WsPanel.kt` 신규) — `GET /inject/sinks` 로 sink 목록을 로드해 드롭다운에 표시. sink 선택 시 preset 버튼을 동적 갱신하고, 버튼 클릭 시 payload 영역을 채움. Inject 버튼은 `POST /inject/{id}` raw body를 발사하고 상태 레이블(성공/실패)로 결과를 표시.
- **MockerToolWindowFactory** (`plugin/.../ui/MockerToolWindowFactory.kt` 수정) — "WebSocket" 탭으로 `WsPanel` 추가. ToolWindow가 REST / WebSocket 두 탭 구조가 됨.
- 리뷰 포인트: sink 로드·inject 모두 백그라운드 Thread + `SwingUtilities.invokeLater` 패턴 (`RestPanel` 일치).
