### PR TITLE
[T16] 세션/라이프사이클 + ToolWindow 배선

### DIFF
--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/session/MockerSession.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/session/MockerSession.kt
@@ -1,0 +1,83 @@
+package net.spooncast.openmocker.plugin.session
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import net.spooncast.openmocker.plugin.adb.AdbException
+import net.spooncast.openmocker.plugin.adb.AdbService
+import net.spooncast.openmocker.plugin.settings.MockerSettings
+
+enum class ConnectionState { IDLE, FORWARDING, CONNECTED, ERROR }
+
+@Service(Service.Level.PROJECT)
+class MockerSession(@Suppress("UNUSED_PARAMETER") project: Project) {
+    private val adb = AdbService()
+    private val settings get() = MockerSettings.getInstance().state
+
+    var connectionState: ConnectionState = ConnectionState.IDLE
+        private set
+    var errorMessage: String? = null
+        private set
+    var selectedSerial: String? = null
+        private set
+
+    private val listeners = mutableListOf<(ConnectionState, String?) -> Unit>()
+
+    private var restPanelCallback: (() -> Unit)? = null
+    private var restPanelStopCallback: (() -> Unit)? = null
+
+    fun addListener(listener: (ConnectionState, String?) -> Unit) {
+        listeners += listener
+    }
+
+    fun removeListener(listener: (ConnectionState, String?) -> Unit) {
+        listeners -= listener
+    }
+
+    fun registerPollingCallbacks(start: () -> Unit, stop: () -> Unit) {
+        restPanelCallback = start
+        restPanelStopCallback = stop
+    }
+
+    fun loadDevices(): Result<List<AdbService.AdbDevice>> = adb.devices()
+
+    fun selectDevice(serial: String?) {
+        selectedSerial = serial
+        MockerSettings.getInstance().state.lastDeviceSerial = serial ?: ""
+    }
+
+    fun startSession(port: Int = settings.port) {
+        val serial = selectedSerial
+        if (serial == null) {
+            transition(ConnectionState.IDLE, null)
+            return
+        }
+        if (settings.autoForward) {
+            transition(ConnectionState.FORWARDING, null)
+            val result = adb.forward(serial, port)
+            if (result.isFailure) {
+                val msg = (result.exceptionOrNull() as? AdbException)?.message
+                    ?: result.exceptionOrNull()?.message
+                    ?: "포워딩 실패"
+                transition(ConnectionState.ERROR, msg)
+                return
+            }
+        }
+        transition(ConnectionState.CONNECTED, null)
+        restPanelCallback?.invoke()
+    }
+
+    fun stopSession(port: Int = settings.port, removeForward: Boolean = false) {
+        restPanelStopCallback?.invoke()
+        if (removeForward) {
+            val serial = selectedSerial
+            if (serial != null) adb.removeForward(serial, port)
+        }
+        transition(ConnectionState.IDLE, null)
+    }
+
+    private fun transition(state: ConnectionState, error: String?) {
+        connectionState = state
+        errorMessage = error
+        listeners.forEach { it(state, error) }
+    }
+}

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/MockerToolWindowFactory.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/MockerToolWindowFactory.kt
@@ -3,27 +3,121 @@ package net.spooncast.openmocker.plugin.ui
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.components.JBLabel
+import net.spooncast.openmocker.plugin.adb.AdbService
 import net.spooncast.openmocker.plugin.net.ControlClient
+import net.spooncast.openmocker.plugin.session.ConnectionState
+import net.spooncast.openmocker.plugin.session.MockerSession
 import net.spooncast.openmocker.plugin.settings.MockerSettings
+import java.awt.BorderLayout
+import java.awt.FlowLayout
+import javax.swing.JButton
+import javax.swing.JComboBox
+import javax.swing.JPanel
+import javax.swing.JTabbedPane
+import javax.swing.SwingUtilities
 
 class MockerToolWindowFactory : ToolWindowFactory {
 
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val session = project.getService(MockerSession::class.java)
         val settings = MockerSettings.getInstance().state
         val client = ControlClient(port = settings.port)
+
         val restPanel = RestPanel(client)
         val wsPanel = WsPanel(client)
+        val statusBar = StatusBar(project)
 
-        val restContent = toolWindow.contentManager.factory.createContent(restPanel, "REST", false)
-        val wsContent = toolWindow.contentManager.factory.createContent(wsPanel, "WebSocket", false)
-        toolWindow.contentManager.addContent(restContent)
-        toolWindow.contentManager.addContent(wsContent)
+        session.registerPollingCallbacks(
+            start = { SwingUtilities.invokeLater { restPanel.startPolling() } },
+            stop = { SwingUtilities.invokeLater { restPanel.stopPolling() } },
+        )
+
+        val sessionListener: (ConnectionState, String?) -> Unit = { state, error ->
+            statusBar.update(state, error)
+        }
+        session.addListener(sessionListener)
+
+        // 기기 드롭다운
+        val deviceCombo = JComboBox<String>()
+        var devices: List<AdbService.AdbDevice> = emptyList()
+
+        fun loadDevices() {
+            Thread {
+                val result = session.loadDevices()
+                SwingUtilities.invokeLater {
+                    deviceCombo.removeAllItems()
+                    if (result.isSuccess) {
+                        devices = result.getOrThrow().filter { it.isOnline }
+                        devices.forEach { deviceCombo.addItem(it.serial) }
+                        val lastSerial = MockerSettings.getInstance().state.lastDeviceSerial
+                        val idx = devices.indexOfFirst { it.serial == lastSerial }
+                        if (idx >= 0) {
+                            deviceCombo.selectedIndex = idx
+                            session.selectDevice(devices[idx].serial)
+                        } else if (devices.isNotEmpty()) {
+                            deviceCombo.selectedIndex = 0
+                            session.selectDevice(devices[0].serial)
+                        } else {
+                            session.selectDevice(null)
+                        }
+                    } else {
+                        devices = emptyList()
+                        session.selectDevice(null)
+                    }
+                }
+            }.apply { isDaemon = true; start() }
+        }
+
+        deviceCombo.addActionListener {
+            val idx = deviceCombo.selectedIndex
+            if (idx >= 0 && idx < devices.size) {
+                session.selectDevice(devices[idx].serial)
+                session.startSession(settings.port)
+            }
+        }
+
+        val refreshButton = JButton("새로고침").apply {
+            addActionListener { loadDevices() }
+        }
+
+        val toolbar = JPanel(FlowLayout(FlowLayout.LEFT, 4, 2)).apply {
+            add(JBLabel("기기:"))
+            add(deviceCombo)
+            add(refreshButton)
+            add(statusBar)
+        }
+
+        val tabs = JTabbedPane().apply {
+            addTab("REST", restPanel)
+            addTab("WebSocket", wsPanel)
+        }
+
+        val mainPanel = JPanel(BorderLayout()).apply {
+            add(toolbar, BorderLayout.NORTH)
+            add(tabs, BorderLayout.CENTER)
+        }
+
+        val content = toolWindow.contentManager.factory.createContent(mainPanel, "", false)
+        toolWindow.contentManager.addContent(content)
 
         toolWindow.contentManager.addContentManagerListener(object :
             com.intellij.ui.content.ContentManagerListener {
             override fun contentRemoved(event: com.intellij.ui.content.ContentManagerEvent) {
-                restPanel.stopPolling()
+                session.stopSession(settings.port, removeForward = true)
+                session.removeListener(sessionListener)
             }
         })
+
+        // ToolWindow 가시성으로 폴링 start/stop
+        toolWindow.component.addPropertyChangeListener("showing") { evt ->
+            if (evt.newValue == true) {
+                session.startSession(settings.port)
+            } else {
+                session.stopSession(settings.port, removeForward = false)
+            }
+        }
+
+        loadDevices()
     }
 }

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RestPanel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RestPanel.kt
@@ -7,6 +7,7 @@ import com.intellij.ui.components.JBTextField
 import com.intellij.ui.table.JBTable
 import net.spooncast.openmocker.plugin.net.ControlClient
 import net.spooncast.openmocker.plugin.net.MockRequest
+import net.spooncast.openmocker.plugin.net.RecordedEntry
 import net.spooncast.openmocker.plugin.settings.MockerSettings
 import java.awt.BorderLayout
 import java.awt.FlowLayout
@@ -16,11 +17,14 @@ import java.awt.Insets
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
+import com.intellij.ui.OnePixelSplitter
 import javax.swing.BorderFactory
 import javax.swing.JButton
 import javax.swing.JPanel
 import javax.swing.ListSelectionModel
 import javax.swing.SwingUtilities
+import javax.swing.event.DocumentEvent
+import javax.swing.event.DocumentListener
 
 class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
 
@@ -40,17 +44,24 @@ class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
     private val clearAllButton = JButton("전체 Clear")
     private val refreshButton = JButton("새로고침")
 
+    // 현재 편집 중인 항목 — 폴링이 selection을 초기화해도 유지됨
+    private var editingEntry: RecordedEntry? = null
+
     private val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { r ->
         Thread(r, "openmocker-poll").apply { isDaemon = true }
     }
 
     init {
-        add(buildToolbar(), BorderLayout.NORTH)
-        add(JBScrollPane(table), BorderLayout.CENTER)
-        add(buildEditPanel(), BorderLayout.SOUTH)
+        val toolbar = buildToolbar()
+        val splitPane = OnePixelSplitter(true, 0.6f).apply {
+            firstComponent = JBScrollPane(table)
+            secondComponent = buildEditPanel()
+        }
+
+        add(toolbar, BorderLayout.NORTH)
+        add(splitPane, BorderLayout.CENTER)
 
         wireActions()
-        startPolling()
     }
 
     private fun buildToolbar(): JPanel = JPanel(FlowLayout(FlowLayout.LEFT, 4, 2)).apply {
@@ -72,10 +83,11 @@ class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
 
         gbc.gridx = 0; gbc.gridy = 1; gbc.weightx = 0.0; gbc.fill = GridBagConstraints.NONE
         add(JBLabel("Body"), gbc)
-        gbc.gridx = 1; gbc.weightx = 1.0; gbc.fill = GridBagConstraints.BOTH
+        gbc.gridx = 1; gbc.weightx = 1.0; gbc.weighty = 1.0; gbc.fill = GridBagConstraints.BOTH
         add(JBScrollPane(bodyArea), gbc)
 
-        gbc.gridx = 0; gbc.gridy = 2; gbc.gridwidth = 2; gbc.fill = GridBagConstraints.NONE
+        gbc.gridx = 0; gbc.gridy = 2; gbc.gridwidth = 2; gbc.weighty = 0.0
+        gbc.fill = GridBagConstraints.NONE
         gbc.anchor = GridBagConstraints.EAST; gbc.weightx = 0.0
         val buttonPanel = JPanel(FlowLayout(FlowLayout.RIGHT, 4, 0)).apply {
             add(clearMockButton)
@@ -88,21 +100,29 @@ class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
         table.selectionModel.addListSelectionListener { e ->
             if (e.valueIsAdjusting) return@addListSelectionListener
             val row = table.selectedRow
-            if (row < 0) {
-                saveButton.isEnabled = false
-                clearMockButton.isEnabled = false
-                return@addListSelectionListener
-            }
+            if (row < 0) return@addListSelectionListener  // 폴링 리셋 시 editingEntry 유지
             val entry = tableModel.getEntryAt(row)
+            editingEntry = entry
             codeField.text = (entry.mock?.code ?: entry.response.code).toString()
             bodyArea.text = entry.mock?.body ?: entry.response.body
             saveButton.isEnabled = true
             clearMockButton.isEnabled = entry.mock != null
         }
 
+        // body/code 수정 시 편집 중인 항목이 있으면 저장 버튼 활성화
+        val editListener = object : DocumentListener {
+            override fun insertUpdate(e: DocumentEvent) = onEdit()
+            override fun removeUpdate(e: DocumentEvent) = onEdit()
+            override fun changedUpdate(e: DocumentEvent) = onEdit()
+            private fun onEdit() {
+                if (editingEntry != null) saveButton.isEnabled = true
+            }
+        }
+        bodyArea.document.addDocumentListener(editListener)
+        codeField.document.addDocumentListener(editListener)
+
         saveButton.addActionListener {
-            val row = table.selectedRow.takeIf { it >= 0 } ?: return@addActionListener
-            val entry = tableModel.getEntryAt(row)
+            val entry = editingEntry ?: return@addActionListener
             val code = codeField.text.trim().toIntOrNull() ?: return@addActionListener
             val body = bodyArea.text
             client.upsertMock(MockRequest(method = entry.method, path = entry.path, code = code, body = body))
@@ -110,21 +130,25 @@ class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
         }
 
         clearMockButton.addActionListener {
-            val row = table.selectedRow.takeIf { it >= 0 } ?: return@addActionListener
-            val entry = tableModel.getEntryAt(row)
+            val entry = editingEntry ?: return@addActionListener
             client.clearMock(method = entry.method, path = entry.path)
+            editingEntry = null
+            clearMockButton.isEnabled = false
             refresh()
         }
 
         clearAllButton.addActionListener {
             client.clearAll()
+            editingEntry = null
+            saveButton.isEnabled = false
+            clearMockButton.isEnabled = false
             refresh()
         }
 
         refreshButton.addActionListener { refresh() }
     }
 
-    private fun startPolling() {
+    fun startPolling() {
         val intervalMs = MockerSettings.getInstance().state.pollIntervalMs.toLong()
         scheduler.scheduleAtFixedRate(::refresh, 0L, intervalMs, TimeUnit.MILLISECONDS)
     }

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/StatusBar.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/StatusBar.kt
@@ -1,0 +1,47 @@
+package net.spooncast.openmocker.plugin.ui
+
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.project.Project
+import com.intellij.ui.JBColor
+import com.intellij.ui.components.JBLabel
+import net.spooncast.openmocker.plugin.session.ConnectionState
+import java.awt.FlowLayout
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
+
+class StatusBar(private val project: Project) : JPanel(FlowLayout(FlowLayout.LEFT, 6, 2)) {
+
+    private val label = JBLabel("● 연결 안 됨").also { add(it) }
+
+    fun update(state: ConnectionState, errorMessage: String? = null) {
+        SwingUtilities.invokeLater {
+            when (state) {
+                ConnectionState.IDLE -> {
+                    label.text = "● 연결 안 됨"
+                    label.foreground = JBColor.GRAY
+                }
+                ConnectionState.FORWARDING -> {
+                    label.text = "◎ 포워딩 중…"
+                    label.foreground = JBColor.ORANGE
+                }
+                ConnectionState.CONNECTED -> {
+                    label.text = "● 연결됨"
+                    label.foreground = JBColor.GREEN
+                }
+                ConnectionState.ERROR -> {
+                    label.text = "✗ 오류"
+                    label.foreground = JBColor.RED
+                    notifyError(errorMessage ?: "알 수 없는 오류")
+                }
+            }
+        }
+    }
+
+    private fun notifyError(message: String) {
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup("OpenMocker")
+            .createNotification("OpenMocker 연결 실패", message, NotificationType.ERROR)
+            .notify(project)
+    }
+}

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -10,11 +10,14 @@
     <depends>com.intellij.modules.platform</depends>
 
     <extensions defaultExtensionNs="com.intellij">
+        <projectService serviceImplementation="net.spooncast.openmocker.plugin.session.MockerSession" />
         <!-- 빈 ToolWindow 골격. REST/WS 패널은 T14/T15 에서 채운다. -->
         <toolWindow
             id="OpenMocker"
             anchor="right"
             factoryClass="net.spooncast.openmocker.plugin.ui.MockerToolWindowFactory" />
+
+        <notificationGroup id="OpenMocker" displayType="BALLOON" />
 
         <!-- 설정 영속화는 @Service(MockerSettings)라 무등록. Settings UI 만 등록한다. -->
         <applicationConfigurable


### PR DESCRIPTION
## Meta

PR Type: feature

Closes #130

## 문제/신규 기능 설명

패널·통신·기기·설정이 각각 분리돼 있어 ToolWindow를 열어도 자동 연결·폴링·상태 피드백이 동작하지 않는 상태였다.
`MockerSession`을 허브로 삼아 기기 선택→adb forward→폴링 시작 흐름을 완성하고, ToolWindow 가시성과 생명주기를 연동한다.

## 적용 버전

0.1.0

## 원인

신규 기능 — 해당 없음

## 수정/구현

- **MockerSession** (`session/MockerSession.kt`, `@Service PROJECT`): `ConnectionState(IDLE/FORWARDING/CONNECTED/ERROR)` 추적, 기기 선택→`AdbService.forward`→폴링 시작/중단, `MockerSettings.lastDeviceSerial` 갱신, listener 패턴으로 UI에 상태 전파.
- **StatusBar** (`ui/StatusBar.kt`): 상태별 색상 레이블 + 에러 시 IntelliJ Balloon Notification.
- **MockerToolWindowFactory** (`ui/MockerToolWindowFactory.kt`): 공유 툴바(기기 드롭다운·새로고침·StatusBar) + `JTabbedPane`(REST/WS); ToolWindow showing 이벤트→`startSession`, 콘텐츠 제거→`stopSession(removeForward=true)`.
- **RestPanel** (`ui/RestPanel.kt`): 폴링을 init에서 분리해 `MockerSession`이 외부에서 호출; `editingEntry`로 편집 항목 추적해 폴링 리셋 후에도 저장 버튼 유지; `OnePixelSplitter`로 테이블·편집 영역 높이 조절 가능.
- **plugin.xml**: `<projectService>` MockerSession 등록, `<notificationGroup id="OpenMocker">` 추가.

리뷰 포인트: `MockerSession.startSession`의 forward 실패 시 에러 전이(`transition(ERROR, …)`)와, ToolWindow hide 시 forward를 유지(폴링만 중단)하고 close 시에만 `removeForward`를 호출하는 생명주기 정책.
