### PR TITLE
플러그인 ToolWindow UI/UX 개선 (REST·WebSocket 탭, 기기 선택)

### DIFF
--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/adb/AdbService.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/adb/AdbService.kt
@@ -71,6 +71,24 @@ class AdbService(
     }
 
     /**
+     * 사람이 읽기 좋은 기기명. 에뮬레이터(`emulator-*`)는 AVD 이름(`emu avd name`)을, 실기기는
+     * `getprop ro.product.model`(예: "Pixel 6a")을 돌려준다. UI 드롭다운 표시용이며 명령 대상
+     * 식별은 여전히 serial 로 한다. 조회 실패는 [Result.failure].
+     */
+    fun deviceName(serial: String): Result<String> = call {
+        if (serial.startsWith(EMULATOR_SERIAL_PREFIX)) {
+            val out = exec(listOf(resolveAdb(), "-s", serial, "emu", "avd", "name"))
+            parseEmuAvdName(out) ?: getProp(serial, PROP_MODEL)
+        } else {
+            getProp(serial, PROP_MODEL)
+        }
+    }
+
+    /** `adb -s <serial> shell getprop <prop>` 의 값(trim). */
+    private fun getProp(serial: String, prop: String): String =
+        exec(listOf(resolveAdb(), "-s", serial, "shell", "getprop", prop)).trim()
+
+    /**
      * adb 실행파일 경로를 결정한다. `ANDROID_HOME` → `ANDROID_SDK_ROOT` 의 `platform-tools/adb`
      * 가 실재하면 그 절대경로를, 둘 다 없으면 `PATH` 위임을 기대하고 `adb` 를 반환한다. 후보 SDK 가
      * 지정됐는데 실행파일이 없으면 [AdbException] 으로 실패시킨다(오타·미설치 조기 발견).
@@ -111,6 +129,21 @@ class AdbService(
 
         /** 정상 연결 상태 토큰. */
         const val STATE_DEVICE = "device"
+
+        /** 에뮬레이터 serial 접두사(예: `emulator-5554`). */
+        private const val EMULATOR_SERIAL_PREFIX = "emulator-"
+
+        /** 기기 모델명 시스템 프로퍼티 키(예: "Pixel 6a"). */
+        private const val PROP_MODEL = "ro.product.model"
+
+        /**
+         * `adb -s <serial> emu avd name` 출력에서 AVD 이름을 뽑는다. 출력은 보통
+         * `"<name>\nOK"` 형태라 빈 줄과 `OK` 종료 토큰을 건너뛴 첫 줄을 쓴다. 없으면 null.
+         */
+        fun parseEmuAvdName(output: String): String? =
+            output.lineSequence()
+                .map { it.trim() }
+                .firstOrNull { it.isNotEmpty() && it != "OK" }
 
         /** adb 탐색 시 우선순위대로 조회하는 SDK 루트 env 키. */
         private val SDK_ENV_KEYS = listOf("ANDROID_HOME", "ANDROID_SDK_ROOT")

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/session/MockerSession.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/session/MockerSession.kt
@@ -40,6 +40,9 @@ class MockerSession(@Suppress("UNUSED_PARAMETER") project: Project) {
 
     fun loadDevices(): Result<List<AdbService.AdbDevice>> = adb.devices()
 
+    /** 드롭다운 표시용 사람이 읽기 좋은 기기명. 실패 시 [Result.failure]. */
+    fun deviceName(serial: String): Result<String> = adb.deviceName(serial)
+
     fun selectDevice(serial: String?) {
         selectedSerial = serial
         MockerSettings.getInstance().state.lastDeviceSerial = serial ?: ""

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/MockerToolWindowFactory.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/MockerToolWindowFactory.kt
@@ -9,6 +9,7 @@ import net.spooncast.openmocker.plugin.net.ControlClient
 import net.spooncast.openmocker.plugin.session.ConnectionState
 import net.spooncast.openmocker.plugin.session.MockerSession
 import net.spooncast.openmocker.plugin.settings.MockerSettings
+import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
 import java.awt.FlowLayout
 import javax.swing.JButton
@@ -45,11 +46,17 @@ class MockerToolWindowFactory : ToolWindowFactory {
         fun loadDevices() {
             Thread {
                 val result = session.loadDevices()
+                val onlineDevices = result.getOrNull()?.filter { it.isOnline }.orEmpty()
+                // 기기명은 EDT 밖에서 미리 조회한다. "<기기명> (<serial>)" 형식, 실패 시 serial 만.
+                val labels = onlineDevices.associate { device ->
+                    val name = session.deviceName(device.serial).getOrNull()?.takeIf { it.isNotBlank() }
+                    device.serial to (name?.let { "$it (${device.serial})" } ?: device.serial)
+                }
                 SwingUtilities.invokeLater {
                     deviceCombo.removeAllItems()
                     if (result.isSuccess) {
-                        devices = result.getOrThrow().filter { it.isOnline }
-                        devices.forEach { deviceCombo.addItem(it.serial) }
+                        devices = onlineDevices
+                        devices.forEach { deviceCombo.addItem(labels[it.serial]) }
                         val lastSerial = MockerSettings.getInstance().state.lastDeviceSerial
                         val idx = devices.indexOfFirst { it.serial == lastSerial }
                         if (idx >= 0) {
@@ -82,6 +89,7 @@ class MockerToolWindowFactory : ToolWindowFactory {
         }
 
         val toolbar = JPanel(FlowLayout(FlowLayout.LEFT, 4, 2)).apply {
+            border = JBUI.Borders.empty(8)
             add(JBLabel("기기:"))
             add(deviceCombo)
             add(refreshButton)

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RecordedTableModel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RecordedTableModel.kt
@@ -5,7 +5,7 @@ import javax.swing.table.AbstractTableModel
 
 class RecordedTableModel : AbstractTableModel() {
 
-    private val columns = arrayOf("Method", "Path", "Mocked?")
+    private val columns = arrayOf("Method", "Path", "Mocked")
     private var entries: List<RecordedEntry> = emptyList()
 
     fun update(newEntries: List<RecordedEntry>) {

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RestPanel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RestPanel.kt
@@ -8,6 +8,7 @@ import com.intellij.ui.EditorNotificationPanel
 import com.intellij.ui.InlineBanner
 import com.intellij.ui.table.JBTable
 import com.intellij.util.ui.JBUI
+import net.spooncast.openmocker.plugin.util.JsonFormatter
 import net.spooncast.openmocker.plugin.net.ControlClient
 import net.spooncast.openmocker.plugin.net.MockRequest
 import net.spooncast.openmocker.plugin.net.RecordedEntry
@@ -40,7 +41,10 @@ class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
     }
 
     private val codeField = JBTextField(6)
-    private val bodyArea = JBTextArea(5, 40).apply { lineWrap = true; wrapStyleWord = true }
+    private val bodyArea = JBTextArea(5, 40).apply {
+        lineWrap = true; wrapStyleWord = true
+        margin = JBUI.insets(6)  // 입력란 안쪽 여백 — Status Code 필드의 기본 LaF inset 과 맞춤
+    }
 
     private val saveButton = JButton("저장").apply { isEnabled = false }
     private val clearMockButton = JButton("Mock 해제").apply { isEnabled = false }
@@ -124,7 +128,7 @@ class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
             val entry = tableModel.getEntryAt(row)
             editingEntry = entry
             codeField.text = (entry.mock?.code ?: entry.response.code).toString()
-            bodyArea.text = entry.mock?.body ?: entry.response.body
+            bodyArea.text = JsonFormatter.pretty(entry.mock?.body ?: entry.response.body)
             saveButton.isEnabled = true
             clearMockButton.isEnabled = entry.mock != null
         }

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RestPanel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RestPanel.kt
@@ -4,7 +4,10 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.components.JBTextField
+import com.intellij.ui.EditorNotificationPanel
+import com.intellij.ui.InlineBanner
 import com.intellij.ui.table.JBTable
+import com.intellij.util.ui.JBUI
 import net.spooncast.openmocker.plugin.net.ControlClient
 import net.spooncast.openmocker.plugin.net.MockRequest
 import net.spooncast.openmocker.plugin.net.RecordedEntry
@@ -32,8 +35,8 @@ class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
     private val table = JBTable(tableModel).apply {
         selectionModel.selectionMode = ListSelectionModel.SINGLE_SELECTION
         setShowGrid(false)
-        columnModel.getColumn(2).maxWidth = 70
-        columnModel.getColumn(2).minWidth = 70
+        // 세 컬럼 모두 사용자가 드래그로 폭 조정 가능. preferredWidth 로 기존 기본 폭만 유지한다.
+        columnModel.getColumn(2).preferredWidth = 70
     }
 
     private val codeField = JBTextField(6)
@@ -52,19 +55,36 @@ class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
     }
 
     init {
-        val toolbar = buildToolbar()
+        border = JBUI.Borders.empty(8)
         val splitPane = OnePixelSplitter(true, 0.6f).apply {
             firstComponent = JBScrollPane(table)
             secondComponent = buildEditPanel()
         }
 
-        add(toolbar, BorderLayout.NORTH)
+        add(buildHeader(), BorderLayout.NORTH)
         add(splitPane, BorderLayout.CENTER)
 
         wireActions()
     }
 
-    private fun buildToolbar(): JPanel = JPanel(FlowLayout(FlowLayout.LEFT, 4, 2)).apply {
+    // 기능 설명을 닫기 가능한 InlineBanner 로 최상단(툴바 위)에 둔다.
+    // 닫기는 세션 한정 — 배너를 제거할 뿐, 툴윈도우를 다시 열면 재등장한다.
+    // 박스 아래 8px 간격은 BorderLayout vgap 으로 줘 배너 자체 스타일은 건드리지 않는다.
+    private fun buildHeader(): JPanel = JPanel(BorderLayout(0, 8)).apply {
+        val banner = InlineBanner(
+            "앱이 보낸 HTTP 요청 목록입니다. 항목을 선택하면 응답(상태 코드·본문)을 원하는 값으로 바꿀 수 있습니다.",
+            EditorNotificationPanel.Status.Info,
+        ).showCloseButton(true)
+        banner.setCloseAction {
+            remove(banner)
+            revalidate()
+            repaint()
+        }
+        add(banner, BorderLayout.NORTH)
+        add(buildToolbar(), BorderLayout.CENTER)
+    }
+
+    private fun buildToolbar(): JPanel = JPanel(FlowLayout(FlowLayout.RIGHT, 4, 2)).apply {
         add(refreshButton)
         add(clearAllButton)
     }

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/WsPanel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/WsPanel.kt
@@ -8,6 +8,7 @@ import com.intellij.ui.components.JBTextArea
 import com.intellij.util.ui.JBUI
 import net.spooncast.openmocker.plugin.net.ControlClient
 import net.spooncast.openmocker.plugin.net.Sink
+import net.spooncast.openmocker.plugin.util.JsonFormatter
 import java.awt.BorderLayout
 import java.awt.FlowLayout
 import javax.swing.JButton
@@ -20,7 +21,10 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
     private var sinks: List<Sink> = emptyList()
     private val sinkCombo = JComboBox<String>()
     private val presetsPanel = JPanel(FlowLayout(FlowLayout.LEFT, 4, 2))
-    private val payloadArea = JBTextArea(8, 40).apply { lineWrap = true; wrapStyleWord = true }
+    private val payloadArea = JBTextArea(8, 40).apply {
+        lineWrap = true; wrapStyleWord = true
+        margin = JBUI.insets(6)  // 입력란 안쪽 여백 — Status Code 필드의 기본 LaF inset 과 맞춤
+    }
     private val injectButton = JButton("보내기").apply { isEnabled = false }
     private val statusLabel = JBLabel("")
     private val refreshButton = JButton("새로고침")
@@ -134,7 +138,7 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
         if (sink.presets.isNotEmpty()) presetsPanel.add(JBLabel("예시 메시지:"))
         sink.presets.forEach { preset ->
             presetsPanel.add(JButton(preset.name).apply {
-                addActionListener { payloadArea.text = preset.payload }
+                addActionListener { payloadArea.text = JsonFormatter.pretty(preset.payload) }
             })
         }
         presetsPanel.revalidate()

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/WsPanel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/WsPanel.kt
@@ -1,8 +1,11 @@
 package net.spooncast.openmocker.plugin.ui
 
+import com.intellij.ui.EditorNotificationPanel
+import com.intellij.ui.InlineBanner
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTextArea
+import com.intellij.util.ui.JBUI
 import net.spooncast.openmocker.plugin.net.ControlClient
 import net.spooncast.openmocker.plugin.net.Sink
 import java.awt.BorderLayout
@@ -18,22 +21,47 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
     private val sinkCombo = JComboBox<String>()
     private val presetsPanel = JPanel(FlowLayout(FlowLayout.LEFT, 4, 2))
     private val payloadArea = JBTextArea(8, 40).apply { lineWrap = true; wrapStyleWord = true }
-    private val injectButton = JButton("Inject").apply { isEnabled = false }
+    private val injectButton = JButton("보내기").apply { isEnabled = false }
     private val statusLabel = JBLabel("")
     private val refreshButton = JButton("새로고침")
 
     init {
-        add(buildToolbar(), BorderLayout.NORTH)
+        border = JBUI.Borders.empty(8)
+        add(buildHeader(), BorderLayout.NORTH)
         add(buildCenterPanel(), BorderLayout.CENTER)
         add(buildSouthPanel(), BorderLayout.SOUTH)
         wireActions()
         loadSinks()
     }
 
-    private fun buildToolbar(): JPanel = JPanel(FlowLayout(FlowLayout.LEFT, 4, 2)).apply {
-        add(refreshButton)
-        add(JBLabel("Sink:"))
-        add(sinkCombo)
+    // 기능 설명을 닫기 가능한 InlineBanner 로 최상단(대상 셀렉터 위)에 둔다.
+    // 닫기는 세션 한정 — 배너를 제거할 뿐, 툴윈도우를 다시 열면 재등장한다.
+    // 박스 아래 8px 간격은 BorderLayout vgap 으로 줘 배너 자체 스타일은 건드리지 않는다.
+    private fun buildHeader(): JPanel = JPanel(BorderLayout(0, 8)).apply {
+        val banner = InlineBanner(
+            "실제 서버 없이, 선택한 대상으로 가짜 메시지를 보내 앱이 메시지를 받는 상황을 재현합니다.",
+            EditorNotificationPanel.Status.Info,
+        ).showCloseButton(true)
+        banner.setCloseAction {
+            remove(banner)
+            revalidate()
+            repaint()
+        }
+        add(banner, BorderLayout.NORTH)
+        add(buildToolbar(), BorderLayout.CENTER)
+    }
+
+    // 대상 셀렉터는 좌측에, 액션 버튼(새로고침)은 우측 끝에 배치한다.
+    private fun buildToolbar(): JPanel = JPanel(BorderLayout()).apply {
+        val left = JPanel(FlowLayout(FlowLayout.LEFT, 4, 2)).apply {
+            add(JBLabel("대상:"))
+            add(sinkCombo)
+        }
+        val right = JPanel(FlowLayout(FlowLayout.RIGHT, 4, 2)).apply {
+            add(refreshButton)
+        }
+        add(left, BorderLayout.WEST)
+        add(right, BorderLayout.EAST)
     }
 
     private fun buildCenterPanel(): JPanel = JPanel(BorderLayout()).apply {
@@ -41,9 +69,16 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
         add(JBScrollPane(payloadArea), BorderLayout.CENTER)
     }
 
-    private fun buildSouthPanel(): JPanel = JPanel(FlowLayout(FlowLayout.LEFT, 4, 4)).apply {
-        add(injectButton)
-        add(statusLabel)
+    // 상태 라벨은 좌측에, Inject 버튼은 우측 끝에 배치한다.
+    private fun buildSouthPanel(): JPanel = JPanel(BorderLayout()).apply {
+        val left = JPanel(FlowLayout(FlowLayout.LEFT, 4, 4)).apply {
+            add(statusLabel)
+        }
+        val right = JPanel(FlowLayout(FlowLayout.RIGHT, 4, 4)).apply {
+            add(injectButton)
+        }
+        add(left, BorderLayout.WEST)
+        add(right, BorderLayout.EAST)
     }
 
     private fun wireActions() {
@@ -86,9 +121,9 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
                         presetsPanel.repaint()
                         injectButton.isEnabled = false
                     }
-                    statusLabel.text = if (sinks.isEmpty()) "등록된 sink 없음" else ""
+                    statusLabel.text = if (sinks.isEmpty()) "등록된 대상 없음" else ""
                 } else {
-                    statusLabel.text = "✗ sink 로드 실패: ${result.exceptionOrNull()?.message}"
+                    statusLabel.text = "✗ 대상 로드 실패: ${result.exceptionOrNull()?.message}"
                 }
             }
         }.apply { isDaemon = true; start() }
@@ -96,6 +131,7 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
 
     private fun updatePresets(sink: Sink) {
         presetsPanel.removeAll()
+        if (sink.presets.isNotEmpty()) presetsPanel.add(JBLabel("예시 메시지:"))
         sink.presets.forEach { preset ->
             presetsPanel.add(JButton(preset.name).apply {
                 addActionListener { payloadArea.text = preset.payload }

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/util/JsonFormatter.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/util/JsonFormatter.kt
@@ -1,0 +1,26 @@
+package net.spooncast.openmocker.plugin.util
+
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonParser
+
+/**
+ * JSON 문자열을 들여쓰기된 형태로 정렬한다. 외부 런타임 의존성 0 원칙에 따라 플랫폼 번들 Gson 만
+ * 사용한다(플러그인의 다른 JSON 처리와 동일).
+ *
+ * 입력이 유효한 JSON 이 아니거나 비어 있으면 원문을 그대로 돌려준다 — Body/payload 에는 plain
+ * text·XML 등 JSON 이 아닌 값도 들어올 수 있어, 정렬 실패가 입력을 훼손하지 않게 한다.
+ */
+object JsonFormatter {
+
+    private val gson = GsonBuilder().setPrettyPrinting().create()
+
+    fun pretty(raw: String): String {
+        if (raw.isBlank()) return raw
+        return try {
+            val element = JsonParser.parseString(raw)
+            if (element.isJsonNull) raw else gson.toJson(element)
+        } catch (e: Exception) {
+            raw
+        }
+    }
+}


### PR DESCRIPTION
## Meta

PR Type: feature

Closes #152

## 문제/신규 기능 설명

플러그인 ToolWindow 의 표기·레이아웃·입력·기기 선택 UX 를 다듬는다. 처음 쓰는 사용자에게
`Sink`/`Inject` 같은 내부 용어와 영숫자 serial 이 모호해, 직관적인 표기·기기명·기능
설명과 일관된 여백·정렬로 진입장벽을 낮추고 가독성을 높인다.

## 적용 버전

0.1.0

## 원인

신규 기능 — 해당 없음

## 수정/구현

- **기기 선택** — `AdbService.deviceName(serial)` 추가(실기기 `ro.product.model`,
  에뮬레이터 `emu avd name`, 실패 시 폴백). 드롭다운에 `기기명 (serial)` 표시.
  기기명은 EDT 밖에서 조회하고, 식별·명령은 serial 유지.
- **REST 탭** — Method·Path·Mocked 컬럼 폭 조정 가능(Mocked 기본 폭 유지),
  헤더 `Mocked?` → `Mocked`.
- **WebSocket 탭** — `Sink` → `대상`, `Inject` → `보내기`, 프리셋 `예시 메시지:` 라벨,
  하단 상태/에러 메시지 `sink` → `대상` 통일.
- **입력란 UX** — Body·payload 에 안쪽 여백(`margin`) 적용(Status Code 필드 inset 과 맞춤),
  불러올 때(기록 항목 선택 / 예시 메시지 클릭) JSON 을 자동 pretty-print
  (번들 Gson, 유효 JSON 아니면 원문 유지).
- **두 탭 공통** — 가장자리·상단 기기 툴바 padding, 버튼 우측 정렬(라벨·콤보 좌측),
  기능 설명을 최상단에 닫기 가능한 InlineBanner(세션 한정)로 제공.
- 리뷰 포인트: 기기명 조회의 EDT 차단 방지(백그라운드 스레드 선조회)와 serial 폴백,
  pretty-print 의 비-JSON 입력 원문 보존, UI 표기만 변경하고 lib 공개 API
  (`Sink`/`OpenMockerEventSink`/`Preset`)는 유지한 점.
