### PR TITLE
소켓 탭에 수신한 소켓 메시지 리스트 추가 (선택→입력란 카피)

### DIFF
--- a/app/src/main/java/net/spooncast/openmocker/demo/WsEventSink.kt
+++ b/app/src/main/java/net/spooncast/openmocker/demo/WsEventSink.kt
@@ -3,6 +3,7 @@ package net.spooncast.openmocker.demo
 import net.spooncast.openmocker.demo.repo.DemoChatSocketClient
 import net.spooncast.openmocker.lib.control.OpenMockerEventSink
 import net.spooncast.openmocker.lib.control.Preset
+import net.spooncast.openmocker.lib.control.ReceivedMessage
 
 /**
  * 제어 서버의 `POST /inject/demo` 로 주입된 payload 를, 데모의 실시간 메시지 스트림으로 흘려보내는 sink.
@@ -29,4 +30,10 @@ class WsEventSink(
         Preset(name = "tick", payload = """{"event":"tick","price":1234}"""),
         Preset(name = "notice", payload = """{"event":"notice","message":"서버 점검 예정"}"""),
     )
+
+    // 데모 소켓이 받은 실제 수신 프레임(최신순)을 그대로 노출한다. 보관은 client 의 책임이고,
+    // sink 는 client 의 ReceivedFrame 을 lib 계약 타입([ReceivedMessage])으로 매핑만 한다.
+    override fun received(): List<ReceivedMessage> = client.recentReceived().map { frame ->
+        ReceivedMessage(seq = frame.seq, payload = frame.payload)
+    }
 }

--- a/app/src/main/java/net/spooncast/openmocker/demo/repo/DemoChatSocketClient.kt
+++ b/app/src/main/java/net/spooncast/openmocker/demo/repo/DemoChatSocketClient.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -30,6 +31,14 @@ class DemoChatSocketClient @Inject constructor() : ChatSocketClient {
     private val _connected = MutableStateFlow(false)
     override val connected: StateFlow<Boolean> = _connected.asStateFlow()
 
+    // 수신 프레임 히스토리(최근 [RECENT_CAPACITY]건). _incoming(replay=0)은 과거를 되읽을 수 없어,
+    // 플러그인의 "수신 메시지" 폴링(GET /inject/demo/received)이 읽어갈 별도 버퍼를 둔다.
+    // emit 은 제어 서버 백그라운드 스레드에서, recentReceived 는 GET 핸들러 스레드에서 호출되므로
+    // 두 접근 모두 lock 으로 보호한다.
+    private val recentLock = Any()
+    private val recent = ArrayDeque<ReceivedFrame>()
+    private val seqCounter = AtomicLong(0L)
+
     override fun connect() {
         _connected.value = true
     }
@@ -41,8 +50,30 @@ class DemoChatSocketClient @Inject constructor() : ChatSocketClient {
     /**
      * 수신 메시지 한 건을 [incoming] 으로 흘려보낸다(운영의 `onMessage` 에 해당).
      * 백그라운드 스레드(제어 서버)에서도 호출되므로 non-suspend `tryEmit` 을 쓴다.
+     *
+     * 같은 자리에서 수신 히스토리 버퍼에도 적재한다 — [incoming] 동작은 그대로 두고 버퍼만 추가한다.
      */
     fun emit(payload: String) {
         _incoming.tryEmit(payload)
+        val frame = ReceivedFrame(seq = seqCounter.incrementAndGet(), payload = payload)
+        synchronized(recentLock) {
+            recent.addLast(frame)
+            while (recent.size > RECENT_CAPACITY) recent.removeFirst()
+        }
+    }
+
+    /** 최근 수신 프레임을 최신순(newest-first)으로 반환한다. */
+    fun recentReceived(): List<ReceivedFrame> = synchronized(recentLock) {
+        recent.toList().asReversed()
+    }
+
+    companion object {
+        private const val RECENT_CAPACITY = 50
     }
 }
+
+/** 수신한 프레임 한 건(일련번호 + 원문). 플러그인 "수신 메시지" 노출용. */
+data class ReceivedFrame(
+    val seq: Long,
+    val payload: String,
+)

--- a/app/src/test/java/net/spooncast/openmocker/demo/repo/DemoChatSocketClientTest.kt
+++ b/app/src/test/java/net/spooncast/openmocker/demo/repo/DemoChatSocketClientTest.kt
@@ -1,0 +1,51 @@
+package net.spooncast.openmocker.demo.repo
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [DemoChatSocketClient] 수신 히스토리 버퍼 단위 테스트.
+ *
+ * 검증: emit 이 최신순 노출·capacity(50) 제한·seq 단조 증가를 지킨다.
+ */
+class DemoChatSocketClientTest {
+
+    @Test
+    fun `recentReceived 는 빈 상태에서 빈 목록을 반환한다`() {
+        val client = DemoChatSocketClient()
+
+        assertEquals(emptyList<ReceivedFrame>(), client.recentReceived())
+    }
+
+    @Test
+    fun `emit 한 프레임을 최신순으로 반환하고 seq 가 단조 증가한다`() {
+        val client = DemoChatSocketClient()
+
+        client.emit("a")
+        client.emit("b")
+        client.emit("c")
+
+        val received = client.recentReceived()
+        assertEquals(listOf("c", "b", "a"), received.map { it.payload })
+        // seq 는 1,2,3 순으로 매겨지고, 최신순 노출이므로 3,2,1
+        assertEquals(listOf(3L, 2L, 1L), received.map { it.seq })
+    }
+
+    @Test
+    fun `버퍼는 최근 50건만 유지한다`() {
+        val client = DemoChatSocketClient()
+
+        repeat(60) { client.emit("msg-$it") }
+
+        val received = client.recentReceived()
+        assertEquals(50, received.size)
+        // 가장 최신(msg-59)이 맨 앞, 가장 오래된 유지분(msg-10)이 맨 뒤
+        assertEquals("msg-59", received.first().payload)
+        assertEquals("msg-10", received.last().payload)
+        // seq 는 끊김 없이 단조 감소(최신순)
+        assertEquals(60L, received.first().seq)
+        assertEquals(11L, received.last().seq)
+        assertTrue(received.zipWithNext().all { (a, b) -> a.seq > b.seq })
+    }
+}

--- a/lib/src/main/java/net/spooncast/openmocker/lib/control/ControlServer.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/control/ControlServer.kt
@@ -150,6 +150,16 @@ internal class ControlServer(
             request.method == "GET" && path == "/inject/sinks" ->
                 200 to json.encodeToString(service.sinks())
 
+            request.method == "GET" && path.startsWith("/inject/") && path.endsWith("/received") -> {
+                val id = path.removePrefix("/inject/").removeSuffix("/received")
+                val received = service.received(id)
+                if (received != null) {
+                    200 to json.encodeToString(received)
+                } else {
+                    404 to errorBody("unknown sink: $id")
+                }
+            }
+
             request.method == "POST" && path.startsWith("/inject/") -> {
                 val id = path.removePrefix("/inject/")
                 // body 는 파싱 없이 통째 전달한다.

--- a/lib/src/main/java/net/spooncast/openmocker/lib/control/ControlService.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/control/ControlService.kt
@@ -3,6 +3,7 @@ package net.spooncast.openmocker.lib.control
 import net.spooncast.openmocker.lib.control.dto.MockRequestDto
 import net.spooncast.openmocker.lib.control.dto.MockDto
 import net.spooncast.openmocker.lib.control.dto.PresetDto
+import net.spooncast.openmocker.lib.control.dto.ReceivedMessageDto
 import net.spooncast.openmocker.lib.control.dto.RecordedEntryDto
 import net.spooncast.openmocker.lib.control.dto.ResponseDto
 import net.spooncast.openmocker.lib.control.dto.SinkDto
@@ -77,6 +78,17 @@ internal class ControlService(
                     PresetDto(name = preset.name, payload = preset.payload)
                 },
             )
+        }
+    }
+
+    /**
+     * `GET /inject/{id}/received` — 해당 sink 가 수신한 프레임 목록을 DTO 로 반환한다.
+     * 등록되지 않은 id 면 null(→ 라우터가 404 로 변환). sinks() 의 preset 매핑과 동일한 형태다.
+     */
+    fun received(id: String): List<ReceivedMessageDto>? {
+        val sink = sinkRegistry.get(id) ?: return null
+        return sink.received().map { msg ->
+            ReceivedMessageDto(seq = msg.seq, payload = msg.payload)
         }
     }
 

--- a/lib/src/main/java/net/spooncast/openmocker/lib/control/OpenMockerEventSink.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/control/OpenMockerEventSink.kt
@@ -21,10 +21,29 @@ interface OpenMockerEventSink {
 
     /** 플러그인 UI 가 버튼으로 노출할 미리 정의된 payload 목록(편의 기능). 없으면 빈 목록. */
     fun presets(): List<Preset>
+
+    /**
+     * sink 가 실제로 수신한 프레임 목록(최신 일부). 플러그인 UI 가 `GET /inject/{id}/received` 로
+     * 폴링해 "수신 메시지" 리스트로 노출하고, 항목을 골라 수정·재주입하는 데 쓴다.
+     *
+     * 보관(버퍼링)은 [presets] 와 마찬가지로 전적으로 sink 구현(앱)의 책임이다 — lib 는 통로일 뿐
+     * 수신 이력을 보관하지 않는다. 기록하지 않는 sink 는 기본 구현(빈 목록)을 그대로 쓰면 된다(opt-in).
+     */
+    fun received(): List<ReceivedMessage> = emptyList()
 }
 
 /** 미리 정의된 주입 payload. [OpenMockerEventSink.presets] 가 반환한다. */
 data class Preset(
     val name: String,
+    val payload: String,
+)
+
+/**
+ * sink 가 수신한 프레임 한 건. [OpenMockerEventSink.received] 가 반환한다.
+ *
+ * [seq] 는 sink 내 단조 증가 일련번호로, 표시 정렬·항목 식별(안정 키)에 쓴다.
+ */
+data class ReceivedMessage(
+    val seq: Long,
     val payload: String,
 )

--- a/lib/src/main/java/net/spooncast/openmocker/lib/control/dto/ControlDtos.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/control/dto/ControlDtos.kt
@@ -62,6 +62,13 @@ internal data class PresetDto(
     val payload: String,
 )
 
+/** `GET /inject/{id}/received` 응답 한 항목. sink 가 수신한 프레임(일련번호 + 원문). */
+@Serializable
+internal data class ReceivedMessageDto(
+    val seq: Long,
+    val payload: String,
+)
+
 /** 성공 응답 공용 바디(`{"ok":true}`). */
 @Serializable
 internal data class OkDto(

--- a/lib/src/test/java/net/spooncast/openmocker/lib/control/ControlServiceTest.kt
+++ b/lib/src/test/java/net/spooncast/openmocker/lib/control/ControlServiceTest.kt
@@ -128,6 +128,44 @@ class ControlServiceTest {
     }
 
     @Test
+    fun `received 는 등록된 sink 의 수신 프레임을 DTO 로 변환한다`() {
+        SinkRegistry.register(object : OpenMockerEventSink {
+            override val id: String = "wala"
+            override val name: String = "WALA"
+            override fun inject(payload: String) = Unit
+            override fun presets(): List<Preset> = emptyList()
+            override fun received(): List<ReceivedMessage> = listOf(
+                ReceivedMessage(seq = 2L, payload = "{\"event\":\"chat\"}"),
+                ReceivedMessage(seq = 1L, payload = "{\"event\":\"tick\"}"),
+            )
+        })
+
+        val received = service.received("wala")
+
+        assertEquals(2, received?.size)
+        assertEquals(2L, received?.first()?.seq)
+        assertEquals("{\"event\":\"chat\"}", received?.first()?.payload)
+        assertEquals(1L, received?.get(1)?.seq)
+        assertEquals("{\"event\":\"tick\"}", received?.get(1)?.payload)
+    }
+
+    @Test
+    fun `received 는 기록하지 않는 sink 면 빈 목록을 반환한다`() {
+        SinkRegistry.register(fakeSink(id = "demo"))
+
+        val received = service.received("demo")
+
+        assertEquals(emptyList<Any>(), received)
+    }
+
+    @Test
+    fun `received 는 미등록 id 면 null 을 반환한다`() {
+        val received = service.received("unknown")
+
+        assertNull(received)
+    }
+
+    @Test
     fun `inject 는 등록된 sink 에 payload 를 전달하고 true 를 반환한다`() {
         var injected: String? = null
         SinkRegistry.register(object : OpenMockerEventSink {

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/net/ContractDtos.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/net/ContractDtos.kt
@@ -54,3 +54,12 @@ data class Preset(
     val name: String,
     val payload: String,
 )
+
+/**
+ * `GET /inject/{id}/received` 응답 한 항목. sink 가 수신한 프레임(일련번호 + 원문).
+ * :lib 의 `ReceivedMessageDto` 와 필드명이 1:1 로 일치해야 한다(Gson 키 매칭).
+ */
+data class ReceivedMessage(
+    val seq: Long,
+    val payload: String,
+)

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/net/ControlClient.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/net/ControlClient.kt
@@ -72,6 +72,14 @@ class ControlClient(
         gson.fromJson<List<Sink>>(res.body(), type) ?: emptyList()
     }
 
+    /** `GET /inject/{id}/received` — 해당 sink 가 수신한 프레임 목록(최신순). 미등록 sink 면 404 → 실패. */
+    fun getReceived(id: String): Result<List<ReceivedMessage>> = call {
+        val res = send(newRequest("/inject/${encode(id)}/received").GET().build())
+        ensureSuccess(res)
+        val type = object : TypeToken<List<ReceivedMessage>>() {}.type
+        gson.fromJson<List<ReceivedMessage>>(res.body(), type) ?: emptyList()
+    }
+
     /** `POST /inject/{id}` — raw payload 를 파싱 없이 그대로 전달. 미등록 sink 면 404 → 실패. */
     fun inject(id: String, payload: String): Result<Unit> = call {
         val res = send(

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/MockerToolWindowFactory.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/MockerToolWindowFactory.kt
@@ -30,8 +30,18 @@ class MockerToolWindowFactory : ToolWindowFactory {
         val statusBar = StatusBar(project)
 
         session.registerPollingCallbacks(
-            start = { SwingUtilities.invokeLater { restPanel.startPolling() } },
-            stop = { SwingUtilities.invokeLater { restPanel.stopPolling() } },
+            start = {
+                SwingUtilities.invokeLater {
+                    restPanel.startPolling()
+                    wsPanel.startPolling()
+                }
+            },
+            stop = {
+                SwingUtilities.invokeLater {
+                    restPanel.stopPolling()
+                    wsPanel.stopPolling()
+                }
+            },
         )
 
         val sessionListener: (ConnectionState, String?) -> Unit = { state, error ->

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/ReceivedTableModel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/ReceivedTableModel.kt
@@ -1,0 +1,37 @@
+package net.spooncast.openmocker.plugin.ui
+
+import net.spooncast.openmocker.plugin.net.ReceivedMessage
+import javax.swing.table.AbstractTableModel
+
+/**
+ * WebSocket 수신 메시지 표 모델. REST 탭의 [RecordedTableModel] 과 같은 골격이되, 컬럼은 단일("수신 메시지")이다.
+ * 셀 값은 payload 를 한 줄로 접은 미리보기로, 행 선택 시 원문([getMessageAt])을 입력란에 복사한다.
+ */
+class ReceivedTableModel : AbstractTableModel() {
+
+    private val columns = arrayOf("수신 메시지")
+    private var rows: List<ReceivedMessage> = emptyList()
+
+    fun update(newRows: List<ReceivedMessage>) {
+        rows = newRows
+        fireTableDataChanged()
+    }
+
+    fun getMessageAt(row: Int): ReceivedMessage = rows[row]
+
+    /** 현재 행들의 seq 스냅샷 — 폴링 시 내용 변화 여부 판단·선택 복원에 쓴다. */
+    fun seqs(): List<Long> = rows.map { it.seq }
+
+    override fun getRowCount(): Int = rows.size
+
+    override fun getColumnCount(): Int = columns.size
+
+    override fun getColumnName(column: Int): String = columns[column]
+
+    override fun getValueAt(rowIndex: Int, columnIndex: Int): Any =
+        rows[rowIndex].payload.replace(WHITESPACE, " ").trim()
+
+    private companion object {
+        val WHITESPACE = Regex("\\s+")
+    }
+}

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/WsPanel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/WsPanel.kt
@@ -2,25 +2,51 @@ package net.spooncast.openmocker.plugin.ui
 
 import com.intellij.ui.EditorNotificationPanel
 import com.intellij.ui.InlineBanner
+import com.intellij.ui.OnePixelSplitter
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTextArea
+import com.intellij.ui.table.JBTable
 import com.intellij.util.ui.JBUI
 import net.spooncast.openmocker.plugin.net.ControlClient
+import net.spooncast.openmocker.plugin.net.ReceivedMessage
 import net.spooncast.openmocker.plugin.net.Sink
+import net.spooncast.openmocker.plugin.settings.MockerSettings
 import net.spooncast.openmocker.plugin.util.JsonFormatter
 import java.awt.BorderLayout
 import java.awt.FlowLayout
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import javax.swing.BorderFactory
 import javax.swing.JButton
 import javax.swing.JComboBox
 import javax.swing.JPanel
+import javax.swing.ListSelectionModel
 import javax.swing.SwingUtilities
 
 class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
 
     private var sinks: List<Sink> = emptyList()
+
+    // 폴링(백그라운드 스레드)이 EDT 의 sinkCombo 를 건드리지 않도록, 현재 선택 sink id 를 별도로 들고 있는다.
+    @Volatile
+    private var selectedSinkId: String? = null
+
     private val sinkCombo = JComboBox<String>()
     private val presetsPanel = JPanel(FlowLayout(FlowLayout.LEFT, 4, 2))
+
+    // 수신 메시지 표 — REST 탭의 JBTable 골격을 따른다(단일 컬럼 "수신 메시지", payload 미리보기).
+    private val receivedModel = ReceivedTableModel()
+    private val receivedTable = JBTable(receivedModel).apply {
+        selectionModel.selectionMode = ListSelectionModel.SINGLE_SELECTION
+        setShowGrid(false)
+        tableHeader.reorderingAllowed = false
+    }
+
+    // 폴링이 항목을 갱신하며 selection 을 복원할 때는, 그 프로그램적 선택이 payloadArea 를 덮지 않게 막는다.
+    private var suppressReceivedSelection = false
+
     private val payloadArea = JBTextArea(8, 40).apply {
         lineWrap = true; wrapStyleWord = true
         margin = JBUI.insets(6)  // 입력란 안쪽 여백 — Status Code 필드의 기본 LaF inset 과 맞춤
@@ -29,11 +55,12 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
     private val statusLabel = JBLabel("")
     private val refreshButton = JButton("새로고침")
 
+    private var scheduler: ScheduledExecutorService? = null
+
     init {
         border = JBUI.Borders.empty(8)
         add(buildHeader(), BorderLayout.NORTH)
-        add(buildCenterPanel(), BorderLayout.CENTER)
-        add(buildSouthPanel(), BorderLayout.SOUTH)
+        add(buildCenterSplit(), BorderLayout.CENTER)
         wireActions()
         loadSinks()
     }
@@ -68,13 +95,22 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
         add(right, BorderLayout.EAST)
     }
 
-    private fun buildCenterPanel(): JPanel = JPanel(BorderLayout()).apply {
-        add(presetsPanel, BorderLayout.NORTH)
-        add(JBScrollPane(payloadArea), BorderLayout.CENTER)
+    // 상단=수신 메시지 표, 하단="편집" 박스. REST 탭과 동일하게 사용자가 경계를 드래그해 비율을 조정한다.
+    private fun buildCenterSplit(): OnePixelSplitter = OnePixelSplitter(true, 0.4f).apply {
+        firstComponent = JBScrollPane(receivedTable)
+        secondComponent = buildEditPanel()
     }
 
-    // 상태 라벨은 좌측에, Inject 버튼은 우측 끝에 배치한다.
-    private fun buildSouthPanel(): JPanel = JPanel(BorderLayout()).apply {
+    // REST 탭의 "편집" 박스 골격: 예시 버튼(NORTH) + payload 입력란(CENTER) + 상태·보내기(SOUTH).
+    private fun buildEditPanel(): JPanel = JPanel(BorderLayout()).apply {
+        border = BorderFactory.createTitledBorder("편집")
+        add(presetsPanel, BorderLayout.NORTH)
+        add(JBScrollPane(payloadArea), BorderLayout.CENTER)
+        add(buildEditFooter(), BorderLayout.SOUTH)
+    }
+
+    // 상태 라벨은 좌측에, Inject 버튼은 우측 끝에(REST 의 저장/해제 버튼 위치와 동일).
+    private fun buildEditFooter(): JPanel = JPanel(BorderLayout()).apply {
         val left = JPanel(FlowLayout(FlowLayout.LEFT, 4, 4)).apply {
             add(statusLabel)
         }
@@ -86,11 +122,28 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
     }
 
     private fun wireActions() {
-        refreshButton.addActionListener { loadSinks() }
+        refreshButton.addActionListener {
+            loadSinks()
+            refreshReceivedAsync()
+        }
 
         sinkCombo.addActionListener {
             val idx = sinkCombo.selectedIndex
-            if (idx >= 0 && idx < sinks.size) updatePresets(sinks[idx])
+            if (idx >= 0 && idx < sinks.size) {
+                selectedSinkId = sinks[idx].id
+                updatePresets(sinks[idx])
+                receivedModel.update(emptyList())  // 대상이 바뀌면 이전 sink 의 수신 목록을 비우고
+                refreshReceivedAsync()             // 새 sink 의 목록을 즉시 가져온다
+            }
+        }
+
+        // 수신 항목을 사용자가 선택하면 payload 를 입력란에 복사한다(preset 클릭과 동일 효과).
+        // 폴링이 selection 을 복원할 때(suppressReceivedSelection)는 복사하지 않는다.
+        receivedTable.selectionModel.addListSelectionListener { e ->
+            if (e.valueIsAdjusting || suppressReceivedSelection) return@addListSelectionListener
+            val row = receivedTable.selectedRow
+            if (row < 0) return@addListSelectionListener
+            payloadArea.text = JsonFormatter.pretty(receivedModel.getMessageAt(row).payload)
         }
 
         injectButton.addActionListener {
@@ -117,12 +170,15 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
                     sinks.forEach { sinkCombo.addItem(it.name) }
                     if (sinks.isNotEmpty()) {
                         sinkCombo.selectedIndex = 0
+                        selectedSinkId = sinks[0].id
                         updatePresets(sinks[0])
                         injectButton.isEnabled = true
                     } else {
+                        selectedSinkId = null
                         presetsPanel.removeAll()
                         presetsPanel.revalidate()
                         presetsPanel.repaint()
+                        receivedModel.update(emptyList())
                         injectButton.isEnabled = false
                     }
                     statusLabel.text = if (sinks.isEmpty()) "등록된 대상 없음" else ""
@@ -143,5 +199,60 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
         }
         presetsPanel.revalidate()
         presetsPanel.repaint()
+    }
+
+    /** 현재 선택된 sink 의 수신 메시지를 (호출 스레드에서) 가져와 EDT 에서 표를 갱신한다. 폴링 스케줄러가 직접 호출한다. */
+    private fun refreshReceived() {
+        val id = selectedSinkId ?: return
+        val result = client.getReceived(id)
+        if (result.isSuccess) {
+            val items = result.getOrThrow()
+            SwingUtilities.invokeLater { updateReceivedList(items) }
+        }
+    }
+
+    /** EDT 트리거(대상 변경·새로고침)용 — [refreshReceived] 를 데몬 스레드로 감싸 호출한다. */
+    private fun refreshReceivedAsync() {
+        Thread(::refreshReceived).apply { isDaemon = true; start() }
+    }
+
+    /**
+     * 수신 표를 새 항목으로 교체한다. 내용(seq 순서)이 같으면 깜빡임·selection churn 을 피해 건너뛴다.
+     * 교체 시에는 기존 선택을 seq 로 복원하되, 그 복원이 payloadArea 를 덮지 않게 한다.
+     */
+    private fun updateReceivedList(items: List<ReceivedMessage>) {
+        if (receivedModel.seqs() == items.map { it.seq }) return
+
+        val selectedSeq = receivedTable.selectedRow
+            .takeIf { it >= 0 }
+            ?.let { receivedModel.getMessageAt(it).seq }
+        suppressReceivedSelection = true
+        try {
+            receivedModel.update(items)
+            val newRow = items.indexOfFirst { it.seq == selectedSeq }
+            if (newRow >= 0) receivedTable.setRowSelectionInterval(newRow, newRow)
+        } finally {
+            suppressReceivedSelection = false
+        }
+    }
+
+    /** ToolWindow 가시 상태에 맞춰 세션이 호출한다(RestPanel 과 동일 생명주기). */
+    fun startPolling() {
+        // 세션 연결(adb forward 직후)에 호출된다. init 시점의 loadSinks 는 forward 전이라 실패할 수 있어,
+        // 아직 sink 를 못 받았으면 여기서(forward 가 선 상태에서) 다시 로드한다. 콤보가 채워지면 그 리스너가
+        // 첫 수신 목록 조회까지 켠다. 이미 받았으면(사용자 선택 보존) 재로딩하지 않는다.
+        if (sinks.isEmpty()) loadSinks()
+        if (scheduler != null) return
+        val intervalMs = MockerSettings.getInstance().state.pollIntervalMs.toLong()
+        val executor = Executors.newSingleThreadScheduledExecutor { r ->
+            Thread(r, "openmocker-ws-poll").apply { isDaemon = true }
+        }
+        scheduler = executor
+        executor.scheduleAtFixedRate(::refreshReceived, 0L, intervalMs, TimeUnit.MILLISECONDS)
+    }
+
+    fun stopPolling() {
+        scheduler?.shutdownNow()
+        scheduler = null
     }
 }

--- a/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/net/ControlClientTest.kt
+++ b/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/net/ControlClientTest.kt
@@ -174,6 +174,41 @@ class ControlClientTest {
     }
 
     @Test
+    fun `getReceived parses received frames newest-first`() {
+        val json = """
+            [{"seq":3,"payload":"{\"event\":\"chat\"}"},
+             {"seq":2,"payload":"{\"event\":\"tick\"}"},
+             {"seq":1,"payload":"raw"}]
+        """.trimIndent()
+        // /inject/sinks 와 분리되도록 더 긴 prefix 컨텍스트로 등록(HttpServer 최장 prefix 매칭).
+        stub("/inject/demo/received", 200, json)
+
+        val result = client.getReceived("demo")
+
+        assertTrue(result.isSuccess)
+        val received = result.getOrThrow()
+        assertEquals(3, received.size)
+        assertEquals(3L, received[0].seq)
+        assertEquals("""{"event":"chat"}""", received[0].payload)
+        assertEquals(1L, received[2].seq)
+        val req = captured["/inject/demo/received"]!!
+        assertEquals("GET", req.method)
+        assertEquals("/inject/demo/received", req.path)
+    }
+
+    @Test
+    fun `getReceived returns failure for unknown sink`() {
+        stub("/inject/ghost/received", 404, """{"ok":false,"error":"unknown sink: ghost"}""")
+
+        val result = client.getReceived("ghost")
+
+        assertTrue(result.isFailure)
+        val ex = result.exceptionOrNull()
+        assertTrue(ex is ControlClientException)
+        assertEquals(404, (ex as ControlClientException).statusCode)
+    }
+
+    @Test
     fun `inject posts raw payload unchanged to sink id`() {
         // /inject/sinks 보다 짧은 prefix 컨텍스트 — HttpServer 는 최장 prefix 매칭이므로 분리됨
         stub("/inject/", 200, """{"ok":true}""")

--- a/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/ui/RecordedTableModelTest.kt
+++ b/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/ui/RecordedTableModelTest.kt
@@ -78,7 +78,7 @@ class RecordedTableModelTest {
     fun `컬럼 이름이 Method Path Mocked 순`() {
         assertEquals("Method", model.getColumnName(0))
         assertEquals("Path", model.getColumnName(1))
-        assertEquals("Mocked?", model.getColumnName(2))
+        assertEquals("Mocked", model.getColumnName(2))
     }
 
     private fun entry(method: String, path: String, mock: MockData? = null) =


### PR DESCRIPTION
## Meta

PR Type: feature

Closes #154

## 문제/신규 기능 설명

소켓(WebSocket) 탭에서 앱 소켓이 실제로 받은 수신 프레임을 골라 수정·재전송할 수 있게 한다.
기존 예시 메시지(presets)는 고정 샘플만 제공해 실제로 오간 메시지 기반 모킹이 불가능했다.
REST 탭의 record→mock 과 동일한 워크플로우를 소켓에도 제공한다.

- 수신 프레임을 sink 가 버퍼링해 `GET /inject/{id}/received` 로 노출
- 플러그인이 폴링해 단일 컬럼 표(JBTable)로 표시 → 항목 선택 시 입력란에 pretty JSON 복사
  → 수정 후 "보내기"
- 전송은 폴링 — 새 WS/SSE 채널 없이 기존 adb forward + HTTP 모델 위에 얹는다

## 적용 버전

0.1.0

## 원인

신규 기능 — 해당 없음

## 수정/구현

- **lib (제어 계약)** — `OpenMockerEventSink.received()` 추가(default empty, opt-in) +
  `ReceivedMessage`/`ReceivedMessageDto`, `ControlService.received()`,
  `GET /inject/{id}/received` 라우트. `presets()` 와 완전 대칭이며 lib 는 통로로만 유지(버퍼 미보유).
- **app (데모)** — `DemoChatSocketClient` 에 수신 링버퍼(최근 50, seq 단조, thread-safe) 추가,
  `WsEventSink.received()` 로 매핑. 버퍼는 socket seam(onMessage 자리)에 둔다.
- **plugin** — `ContractDtos.ReceivedMessage`, `ControlClient.getReceived()`,
  `WsPanel` 을 REST 골격(단일 컬럼 `JBTable` + "편집" titled box)으로 재구성,
  `ReceivedTableModel`, 폴링 생명주기 배선(`MockerToolWindowFactory`).
- **test** — `ControlService`/`ControlClient`/`DemoChatSocketClient` 단위 테스트 추가.
  별도 커밋으로 선재 실패하던 `RecordedTableModelTest` 컬럼명(`Mocked`) 정렬.

### 리뷰 포인트
- **버퍼 소유 위치** — "해석·보관은 sink(앱) 책임" 원칙대로 lib 가 아닌 데모 앱이 버퍼를 가짐.
- **WsPanel sink 로딩 타이밍 (버그 수정)** — 기존엔 `init`(adb forward 이전) 한 번만 sink 를
  로드해 `selectedSinkId == null` 로 수신 폴링이 매번 early-return → 리스트가 비어 보였다.
  연결(`startPolling`, forward 직후) 시점에 미로딩이면 재로딩하도록 수정.
- **폴링 non-clobber** — 폴링이 표를 갱신할 때 seq 로 선택을 복원하되, 사용자가 편집 중인
  입력란을 덮지 않도록 `suppressReceivedSelection` 가드.

### 검증
- 실기기(Pixel 6a) E2E — `POST /inject/demo` → `GET /inject/demo/received` 반영, 최신순·
  seq 단조·용량 50 캡·미등록 sink 404·UTF-8(한글+이모지) 왕복 보존 확인.
- lib·app·plugin 단위 테스트 전부 통과.
