### PR TITLE
WebSocket 수신 메시지 Clear 추가 및 플러그인 저장 실패 노출

### DIFF
--- a/app/src/main/java/net/spooncast/openmocker/demo/WsEventSink.kt
+++ b/app/src/main/java/net/spooncast/openmocker/demo/WsEventSink.kt
@@ -36,4 +36,7 @@ class WsEventSink(
     override fun received(): List<ReceivedMessage> = client.recentReceived().map { frame ->
         ReceivedMessage(seq = frame.seq, payload = frame.payload)
     }
+
+    // 수신 이력 비우기도 client 에 위임한다 — REST 의 전체 Clear 와 동일하게 플러그인이 호출한다.
+    override fun clearReceived() = client.clearRecent()
 }

--- a/app/src/main/java/net/spooncast/openmocker/demo/repo/DemoChatSocketClient.kt
+++ b/app/src/main/java/net/spooncast/openmocker/demo/repo/DemoChatSocketClient.kt
@@ -67,6 +67,11 @@ class DemoChatSocketClient @Inject constructor() : ChatSocketClient {
         recent.toList().asReversed()
     }
 
+    /** 수신 히스토리 버퍼를 비운다(플러그인의 수신 Clear). seq 카운터는 유지해 이후 프레임과 구분된다. */
+    fun clearRecent() = synchronized(recentLock) {
+        recent.clear()
+    }
+
     companion object {
         private const val RECENT_CAPACITY = 50
     }

--- a/lib/src/main/java/net/spooncast/openmocker/lib/control/ControlServer.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/control/ControlServer.kt
@@ -160,6 +160,15 @@ internal class ControlServer(
                 }
             }
 
+            request.method == "DELETE" && path.startsWith("/inject/") && path.endsWith("/received") -> {
+                val id = path.removePrefix("/inject/").removeSuffix("/received")
+                if (service.clearReceived(id)) {
+                    200 to json.encodeToString(OkDto())
+                } else {
+                    404 to errorBody("unknown sink: $id")
+                }
+            }
+
             request.method == "POST" && path.startsWith("/inject/") -> {
                 val id = path.removePrefix("/inject/")
                 // body 는 파싱 없이 통째 전달한다.

--- a/lib/src/main/java/net/spooncast/openmocker/lib/control/ControlService.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/control/ControlService.kt
@@ -93,6 +93,16 @@ internal class ControlService(
     }
 
     /**
+     * `DELETE /inject/{id}/received` — 해당 sink 의 수신 이력 버퍼를 비운다(REST 의 전체 Clear 대응).
+     * 등록되지 않은 id 면 false(→ 라우터가 404 로 변환).
+     */
+    fun clearReceived(id: String): Boolean {
+        val sink = sinkRegistry.get(id) ?: return false
+        sink.clearReceived()
+        return true
+    }
+
+    /**
      * `POST /inject/{id}` — 해당 sink 에 raw payload 를 주입한다.
      * 등록되지 않은 id 면 false 를 반환한다.
      */

--- a/lib/src/main/java/net/spooncast/openmocker/lib/control/OpenMockerEventSink.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/control/OpenMockerEventSink.kt
@@ -30,6 +30,15 @@ interface OpenMockerEventSink {
      * 수신 이력을 보관하지 않는다. 기록하지 않는 sink 는 기본 구현(빈 목록)을 그대로 쓰면 된다(opt-in).
      */
     fun received(): List<ReceivedMessage> = emptyList()
+
+    /**
+     * sink 의 수신 이력 버퍼를 비운다. 플러그인 UI 가 `DELETE /inject/{id}/received` 로 호출해
+     * REST 의 "전체 Clear" 와 동일하게 수신 목록을 초기화하는 데 쓴다.
+     *
+     * [received] 와 마찬가지로 보관은 sink 구현(앱)의 책임이라, 비우는 동작도 구현이 맡는다.
+     * 이력을 기록하지 않는 sink 는 기본 구현(no-op)을 그대로 쓰면 된다(opt-in).
+     */
+    fun clearReceived() = Unit
 }
 
 /** 미리 정의된 주입 payload. [OpenMockerEventSink.presets] 가 반환한다. */

--- a/lib/src/test/java/net/spooncast/openmocker/lib/control/ControlServiceTest.kt
+++ b/lib/src/test/java/net/spooncast/openmocker/lib/control/ControlServiceTest.kt
@@ -187,4 +187,28 @@ class ControlServiceTest {
 
         assertFalse(result)
     }
+
+    @Test
+    fun `clearReceived 는 등록된 sink 의 clearReceived 를 호출하고 true 를 반환한다`() {
+        var cleared = false
+        SinkRegistry.register(object : OpenMockerEventSink {
+            override val id: String = "wala"
+            override val name: String = "WALA"
+            override fun inject(payload: String) = Unit
+            override fun presets(): List<Preset> = emptyList()
+            override fun clearReceived() { cleared = true }
+        })
+
+        val result = service.clearReceived("wala")
+
+        assertTrue(result)
+        assertTrue(cleared)
+    }
+
+    @Test
+    fun `clearReceived 는 미등록 id 면 false 를 반환한다`() {
+        val result = service.clearReceived("unknown")
+
+        assertFalse(result)
+    }
 }

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/net/ControlClient.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/net/ControlClient.kt
@@ -80,6 +80,12 @@ class ControlClient(
         gson.fromJson<List<ReceivedMessage>>(res.body(), type) ?: emptyList()
     }
 
+    /** `DELETE /inject/{id}/received` — 해당 sink 의 수신 이력 버퍼를 비운다. 미등록 sink 면 404 → 실패. */
+    fun clearReceived(id: String): Result<Unit> = call {
+        val res = send(newRequest("/inject/${encode(id)}/received").DELETE().build())
+        ensureSuccess(res)
+    }
+
     /** `POST /inject/{id}` — raw payload 를 파싱 없이 그대로 전달. 미등록 sink 면 404 → 실패. */
     fun inject(id: String, payload: String): Result<Unit> = call {
         val res = send(

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RestPanel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RestPanel.kt
@@ -4,6 +4,7 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.components.JBTextField
+import com.intellij.openapi.ui.Messages
 import com.intellij.ui.EditorNotificationPanel
 import com.intellij.ui.InlineBanner
 import com.intellij.ui.table.JBTable
@@ -147,22 +148,30 @@ class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
 
         saveButton.addActionListener {
             val entry = editingEntry ?: return@addActionListener
-            val code = codeField.text.trim().toIntOrNull() ?: return@addActionListener
+            val raw = codeField.text.trim()
+            val code = raw.toIntOrNull()
+            if (code == null) {
+                Messages.showErrorDialog(this, "Status Code 는 숫자여야 합니다: '$raw'", "Mock 저장 실패")
+                return@addActionListener
+            }
             val body = bodyArea.text
-            client.upsertMock(MockRequest(method = entry.method, path = entry.path, code = code, body = body))
+            val result = client.upsertMock(MockRequest(method = entry.method, path = entry.path, code = code, body = body))
+            if (reportIfFailed(result, "Mock 저장 실패")) return@addActionListener
             refresh()
         }
 
         clearMockButton.addActionListener {
             val entry = editingEntry ?: return@addActionListener
-            client.clearMock(method = entry.method, path = entry.path)
+            val result = client.clearMock(method = entry.method, path = entry.path)
+            if (reportIfFailed(result, "Mock 해제 실패")) return@addActionListener
             editingEntry = null
             clearMockButton.isEnabled = false
             refresh()
         }
 
         clearAllButton.addActionListener {
-            client.clearAll()
+            val result = client.clearAll()
+            if (reportIfFailed(result, "전체 Clear 실패")) return@addActionListener
             editingEntry = null
             saveButton.isEnabled = false
             clearMockButton.isEnabled = false
@@ -175,6 +184,16 @@ class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
     fun startPolling() {
         val intervalMs = MockerSettings.getInstance().state.pollIntervalMs.toLong()
         scheduler.scheduleAtFixedRate(::refresh, 0L, intervalMs, TimeUnit.MILLISECONDS)
+    }
+
+    /**
+     * [ControlClient] 호출 [Result] 가 실패면 에러 다이얼로그를 띄우고 true 를 반환한다.
+     * 제어 서버 미연결(adb forward 없음)·비2xx 응답 등 실패가 조용히 묻히지 않도록 한다.
+     */
+    private fun reportIfFailed(result: Result<Unit>, title: String): Boolean {
+        val cause = result.exceptionOrNull() ?: return false
+        Messages.showErrorDialog(this, cause.message ?: "알 수 없는 오류", title)
+        return true
     }
 
     private fun refresh() {

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/WsPanel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/WsPanel.kt
@@ -54,6 +54,7 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
     private val injectButton = JButton("보내기").apply { isEnabled = false }
     private val statusLabel = JBLabel("")
     private val refreshButton = JButton("새로고침")
+    private val clearReceivedButton = JButton("수신 Clear").apply { isEnabled = false }
 
     private var scheduler: ScheduledExecutorService? = null
 
@@ -90,6 +91,7 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
         }
         val right = JPanel(FlowLayout(FlowLayout.RIGHT, 4, 2)).apply {
             add(refreshButton)
+            add(clearReceivedButton)
         }
         add(left, BorderLayout.WEST)
         add(right, BorderLayout.EAST)
@@ -125,6 +127,19 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
         refreshButton.addActionListener {
             loadSinks()
             refreshReceivedAsync()
+        }
+
+        // 선택된 sink 의 수신 이력을 비운다(REST 의 전체 Clear 대응). 성공하면 서버 진실로 표를 다시 채운다.
+        clearReceivedButton.addActionListener {
+            val id = selectedSinkId ?: return@addActionListener
+            Thread {
+                val result = client.clearReceived(id)
+                SwingUtilities.invokeLater {
+                    statusLabel.text = if (result.isSuccess) "● 수신 목록 비움"
+                    else "✗ 수신 Clear 실패: ${result.exceptionOrNull()?.message}"
+                }
+                if (result.isSuccess) refreshReceived()
+            }.apply { isDaemon = true; start() }
         }
 
         sinkCombo.addActionListener {
@@ -173,6 +188,7 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
                         selectedSinkId = sinks[0].id
                         updatePresets(sinks[0])
                         injectButton.isEnabled = true
+                        clearReceivedButton.isEnabled = true
                     } else {
                         selectedSinkId = null
                         presetsPanel.removeAll()
@@ -180,6 +196,7 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
                         presetsPanel.repaint()
                         receivedModel.update(emptyList())
                         injectButton.isEnabled = false
+                        clearReceivedButton.isEnabled = false
                     }
                     statusLabel.text = if (sinks.isEmpty()) "등록된 대상 없음" else ""
                 } else {

--- a/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/net/ControlClientTest.kt
+++ b/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/net/ControlClientTest.kt
@@ -209,6 +209,28 @@ class ControlClientTest {
     }
 
     @Test
+    fun `clearReceived sends DELETE to sink received path`() {
+        stub("/inject/demo/received", 200, """{"ok":true}""")
+
+        val result = client.clearReceived("demo")
+
+        assertTrue(result.isSuccess)
+        val req = captured["/inject/demo/received"]!!
+        assertEquals("DELETE", req.method)
+        assertEquals("/inject/demo/received", req.path)
+    }
+
+    @Test
+    fun `clearReceived returns failure for unknown sink`() {
+        stub("/inject/ghost/received", 404, """{"ok":false,"error":"unknown sink: ghost"}""")
+
+        val result = client.clearReceived("ghost")
+
+        assertTrue(result.isFailure)
+        assertEquals(404, (result.exceptionOrNull() as ControlClientException).statusCode)
+    }
+
+    @Test
     fun `inject posts raw payload unchanged to sink id`() {
         // /inject/sinks 보다 짧은 prefix 컨텍스트 — HttpServer 는 최장 prefix 매칭이므로 분리됨
         stub("/inject/", 200, """{"ok":true}""")


### PR DESCRIPTION
## Meta

PR Type: feature

## 문제/신규 기능 설명

- **신규 기능** — REST 의 "전체 Clear" 처럼, WebSocket(소켓) 탭의 **수신 메시지 목록을 비우는** 경로를 추가한다. 기존엔 수신 이력을 비울 수단이 없어 새로고침해도 계속 노출됐다(50건 링버퍼 캡/앱 재시작으로만 정리 가능).
- **버그 수정** — 플러그인 REST 탭에서 mock 저장/해제 실패가 **조용히 묻히던** 문제. 제어 서버 미연결(adb forward 없음)·비2xx 응답에도 사용자에게 아무 피드백이 없어 "바꿨는데 안 된다"로 보였다.

## 적용 버전

0.1.0

## 원인

- 수신 Clear: 신규 기능 — 해당 없음
- 저장 실패 노출: `RestPanel` 의 저장/해제 액션이 `ControlClient` 호출의 `Result` 를 확인하지 않고 버려, 실패가 UI에 드러나지 않았다.

## 수정/구현

- **lib (통로 원칙 유지)** — `OpenMockerEventSink.clearReceived()` 를 opt-in 기본 no-op 으로 추가하고, `ControlService.clearReceived(id)` + `DELETE /inject/{id}/received` 라우트를 연다(미등록 id → 404). 수신 이력의 보관·비우기는 모두 sink 구현 책임.
- **app (실제 버퍼)** — `DemoChatSocketClient.clearRecent()` 가 lock 으로 보호된 `recent` 버퍼를 비우고, `WsEventSink.clearReceived()` 가 이를 위임.
- **plugin (UI)** — `ControlClient.clearReceived(id)` 추가, `WsPanel` 툴바에 **"수신 Clear"** 버튼 추가(성공 시 서버 진실로 표 갱신, 실패 시 사유 노출). `RestPanel` 은 `reportIfFailed` 로 저장/해제 실패를 에러 다이얼로그로 띄우고, 숫자 아닌 Status Code 도 명시 안내.
- **검증** — 라이브 디바이스(Pixel 6a)에서 주입→수신→Clear→비워짐 E2E 통과. lib `ControlServiceTest` +2, plugin `ControlClientTest` +2 단위 테스트 추가.
- 리뷰 포인트: lib 의 "통로일 뿐 보관 안 함" 원칙이 `clearReceived` 에도 일관되게 적용됐는지, `DELETE` 라우트의 path 매칭(`startsWith /inject/` + `endsWith /received`).
