### PR TITLE
[T17] 플러그인 패키징/배포

### DIFF
--- a/.claude/docs/decisions/README.md
+++ b/.claude/docs/decisions/README.md
@@ -7,7 +7,7 @@
 
 | 파일 | 한 줄 요약 | 상태 | 갱신일 |
 |---|---|---|---|
-| _(아직 항목 없음)_ | | | |
+| [plugin-distribution-internal-zip.md](plugin-distribution-internal-zip.md) | 플러그인은 사내 zip 수동 배포(마켓플레이스 X), untilBuild 개방형 | 채택됨 | 2026-06-24 |
 
 ## 항목 작성 템플릿
 

--- a/.claude/docs/decisions/plugin-distribution-internal-zip.md
+++ b/.claude/docs/decisions/plugin-distribution-internal-zip.md
@@ -1,0 +1,33 @@
+# 플러그인 배포는 사내 zip 수동 배포 (마켓플레이스 X, untilBuild 개방형)
+
+- 날짜: 2026-06-24
+- 상태: 채택됨
+
+## 맥락
+`plugin/`(OpenMocker 제어용 IntelliJ/AS 플러그인)을 실사용 가능하게 배포해야 했다(T17 / #131).
+이 플러그인은 사내 QA·개발용 제어 도구로, 외부 사용자를 대상으로 하지 않는다. 배포 채널과
+AS/IDEA 호환 상한(`untilBuild`)을 확정해야 했다.
+
+## 결정
+- **배포 채널**: 사내 **zip 수동 배포**를 1순위로 한다. `./gradlew buildPlugin` 산출
+  `plugin/build/distributions/openmocker-plugin-<version>.zip` 을 팀에 공유하고, 각자
+  *Settings → Plugins → Install Plugin from Disk…* 로 설치한다.
+- **JetBrains Marketplace 미사용** — `publishPlugin` 을 배선하지 않는다.
+- **`untilBuild` 개방형(상한 없음)** — `ideaVersion { sinceBuild = "242"; untilBuild = provider { null } }`.
+  sinceBuild=242(AS Ladybug 2024.2+) 이상이면 최신 IDE 에서도 로드 가능.
+- 배포 전 점검으로 `pluginVerification { ides { recommended() } }` 를 배선해 `verifyPlugin`(IntelliJ
+  Plugin Verifier)을 수동 실행 가능하게 둔다.
+
+## 근거 / 검토한 대안
+- **마켓플레이스 vs 사내 zip**: 사내 전용 도구라 공개 마켓이 불필요하고, 심사·공개 노출 부담만 는다 → 사내 zip 채택.
+- **`untilBuild` 고정("243.*") vs 개방형**: 고정하면 새 AS/IDEA 가 나올 때마다 상한을 올려 재배포해야 한다.
+  사내 도구는 최신 AS 를 빠르게 추종하므로 그 리빌드 부담을 없애려 개방형 채택. 대가로 플랫폼 파괴적
+  변경 시 깨질 위험은 감수한다(필요 시 `verifyPlugin` 으로 사전 점검).
+- **내부 plugin repo(`updatePlugins.xml`) / `signPlugin`**: IDE 내 자동 업데이트·서명은 유용하나
+  현 사용 규모엔 과하다 → 향후 옵션으로 보류.
+
+## 영향
+- `plugin/build.gradle.kts` — `untilBuild = provider { null }` + `pluginVerification { ides { recommended() } }`.
+- `plugin/src/main/resources/META-INF/plugin.xml` — 0.1.0 `<change-notes>` 추가.
+- `README.md` — `## IDE Plugin` 섹션에 "Installing the plugin" + "Building & distributing (internal)" 절 추가.
+- 새 AS/IDEA 출시 시 플러그인 재배포 불필요(개방형). 단, 플랫폼 파괴적 변경이 의심되면 `verifyPlugin` 으로 확인 후 배포.

--- a/README.md
+++ b/README.md
@@ -174,7 +174,20 @@ fire WebSocket events without leaving the IDE. It talks to the library's control
 
 1. The app integrates the library and calls `OpenMocker.startControlServer()` (see [Quick Start](#quick-start)).
 2. The app is running on a connected device/emulator (debug build).
-3. The OpenMocker plugin is installed in Android Studio / IntelliJ.
+3. The OpenMocker plugin is installed in Android Studio / IntelliJ (see below).
+
+**Installing the plugin**
+
+The plugin is distributed internally as a `.zip` (it is **not** published to the JetBrains Marketplace).
+
+1. Get the latest `openmocker-plugin-<version>.zip` from the team (shared drive / chat), or build it
+   yourself (see [Building & distributing](#building--distributing-the-plugin-internal)).
+2. In Android Studio / IntelliJ open **Settings → Plugins → ⚙️ → Install Plugin from Disk…** and pick
+   the `.zip`.
+3. Restart the IDE when prompted.
+
+> Requires a build **242 or newer** (Android Studio Ladybug 2024.2+ / IntelliJ IDEA 2024.2+). There is
+> no upper bound, so newer IDE versions are supported without reinstalling a rebuilt plugin.
 
 **Usage**
 
@@ -206,6 +219,29 @@ Because it's a plain HTTP API, you can also drive it from `curl` for scripting:
 adb forward tcp:8099 tcp:8099
 curl -X POST localhost:8099/inject/chat -d '{"event":"chat","text":"hello"}'
 ```
+
+### Building & distributing the plugin (internal)
+
+The plugin lives in `plugin/` as a standalone Gradle build. To produce a distributable archive:
+
+```bash
+cd plugin
+./gradlew buildPlugin
+```
+
+This writes `plugin/build/distributions/openmocker-plugin-<version>.zip`. Share that `.zip` with the
+team and install it via **Install Plugin from Disk…** (see [Installing the plugin](#ide-plugin-android-studio--intellij)).
+
+Optional checks before sharing:
+
+```bash
+./gradlew verifyPluginStructure   # validate plugin.xml + archive layout (fast)
+./gradlew verifyPlugin            # run the IntelliJ Plugin Verifier (downloads target IDEs)
+```
+
+Distribution is **manual zip sharing**; the JetBrains Marketplace is not used. Hosting an internal
+plugin repository (`updatePlugins.xml`) for in-IDE auto-updates, and signing the archive
+(`./gradlew signPlugin`), are possible future options but are not set up today.
 
 ## How It Works
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
     id("org.jetbrains.kotlin.jvm") version "2.2.0"
-    // 2.x. 2.7.0+ 는 Gradle 9 를 요구하므로 루트와 동일한 Gradle 8.13 에 맞춰 2.6.0 고정(상향은 T17 에서).
+    // 2.x. 2.7.0+ 는 Gradle 9 를 요구하므로 루트와 동일한 Gradle 8.13 에 맞춰 2.6.0 고정(T17 에서 유지 확정).
     id("org.jetbrains.intellij.platform") version "2.6.0"
 }
 
@@ -33,8 +33,18 @@ dependencies {
 intellijPlatform {
     pluginConfiguration {
         ideaVersion {
+            // 사내 zip 수동 배포 — sinceBuild=242(AS Ladybug 2024.2+) 이상이면 모두 로드 가능하도록
+            // untilBuild 상한을 두지 않는다(개방형). 미설정 시 2.x 가 기본값 "242.*" 를 박아 최신
+            // AS/IDEA 로드를 막으므로 명시적으로 null 을 줘 상한을 제거한다. 결정: decisions/plugin-distribution-internal-zip.md
             sinceBuild = "242"
-            // untilBuild 와 pluginVerification 상세는 T17(패키징/배포)에서 확정한다.
+            untilBuild = provider { null }
+        }
+    }
+    // 사내 배포 전 호환성 점검. recommended() 는 sinceBuild~untilBuild 범위의 권장 IDE 들을 대상으로
+    // IntelliJ Plugin Verifier 를 돌린다. (필요 시 ./gradlew verifyPlugin 으로 수동 실행 — IDE 다운로드 동반)
+    pluginVerification {
+        ides {
+            recommended()
         }
     }
     // 커스텀 설정(Settings UI)이 없는 골격 단계 — 검색 옵션 빌드를 꺼 빌드 시간을 줄인다(T13 에서 재검토).

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -7,6 +7,16 @@
         WebSocket events on a connected Android device.
     ]]></description>
 
+    <change-notes><![CDATA[
+        <b>0.1.0</b> — first internal release.
+        <ul>
+            <li>Tool window control panel for a connected Android device (REST + WebSocket).</li>
+            <li>Device dropdown with automatic <code>adb forward</code>.</li>
+            <li>REST tab: poll recorded requests, edit/save mocks, un-mock or clear all.</li>
+            <li>WebSocket tab: pick a sink, fire preset or custom payloads, list received frames.</li>
+        </ul>
+    ]]></change-notes>
+
     <depends>com.intellij.modules.platform</depends>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
## Meta

PR Type: feature

Closes #131

## 문제/신규 기능 설명

OpenMocker 제어용 IDE 플러그인(`plugin/`)을 **사내 배포해 실사용 가능**하게 패키징한다.
플러그인 코드(T10~T16)는 완성됐으나 배포 메타·절차가 비어 있어, 배포 채널과 AS/IDEA
호환 범위를 확정하고 설치/배포 문서를 갖춘다. (부모 에픽 #114의 마지막 작업)

## 적용 버전

플러그인 0.1.0 (라이브러리 변경 없음)

## 원인

신규 기능 — 해당 없음

## 수정/구현

- **호환 범위** — `untilBuild` 를 개방형(`provider { null }`)으로 두어 `sinceBuild=242`
  (AS Ladybug 2024.2+) 이상 모든 IDE 에서 로드 가능. 새 AS 출시마다 재배포할 필요 없음.
- **검증 배선** — `pluginVerification { ides { recommended() } }` 추가. `verifyPlugin` 으로
  사내 배포 전 호환성 점검 가능.
- **릴리스 노트** — `plugin.xml` 에 0.1.0 `<change-notes>` 추가.
- **문서** — README `## IDE Plugin` 에 설치(Install from Disk) + 사내 zip 배포(`buildPlugin`)
  절차 추가. 배포 채널 결정(사내 zip 수동, 마켓플레이스 X, untilBuild 개방형)을
  `.claude/docs/decisions/` 에 기록.
- 리뷰 포인트: `untilBuild` 개방형 선택의 트레이드오프(최신 IDE 추종 vs 플랫폼 파괴 변경
  위험)는 decisions 문서에 근거 정리. `signPlugin`/내부 repo 는 향후 옵션으로 보류.

## 검증

- `verifyPluginProjectConfiguration` + `verifyPluginStructure` 통과
- `clean buildPlugin` → `openmocker-plugin-0.1.0.zip` 산출, 패키징된 plugin.xml 에
  `since-build="242"` 상한 없음 + change-notes 반영 확인
