### PR TITLE
플러그인 REST 탭 Delay(ms) 입력란 추가 및 UX·서버 견고성 개선

### DIFF
--- a/lib/src/main/java/net/spooncast/openmocker/lib/control/ControlServer.kt
+++ b/lib/src/main/java/net/spooncast/openmocker/lib/control/ControlServer.kt
@@ -21,6 +21,7 @@ import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.ServerSocket
 import java.net.Socket
+import java.net.SocketTimeoutException
 import java.net.URLDecoder
 
 /**
@@ -102,11 +103,18 @@ internal class ControlServer(
 
     private fun handle(socket: Socket) {
         socket.use { s ->
+            // 소켓 read 타임아웃 — 아무것도(또는 일부만) 보내지 않는 half-open 커넥션이 readHttpRequest 의
+            // 블로킹 read 에서 IO 스레드를 무한 점유하는 것을 막는다. 타임아웃 시 read 가
+            // SocketTimeoutException 을 던지고, 아래 catch 가 응답/종료로 스레드를 반환한다.
+            // 루프백+adb 경유라 정상 요청은 즉시 도착하므로 짧은 타임아웃으로 충분하다.
+            s.soTimeout = SOCKET_READ_TIMEOUT_MS
             val output = s.getOutputStream()
             try {
                 val request = readHttpRequest(s.getInputStream())
                 val (status, body) = route(request)
                 writeResponse(output, status, body)
+            } catch (e: SocketTimeoutException) {
+                // half-open/지연 커넥션 — 응답을 쓸 대상이 없으므로 조용히 닫는다(use 가 닫음).
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to handle control request", e)
                 try {
@@ -233,6 +241,9 @@ internal class ControlServer(
     companion object {
         private const val TAG = "OpenMockerControlServer"
         const val DEFAULT_PORT = 8099
+
+        // 커넥션당 read 타임아웃(ms). 루프백 경유 제어 요청은 즉시 도착하므로 넉넉하면서도 유한한 값.
+        private const val SOCKET_READ_TIMEOUT_MS = 10_000
     }
 }
 

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/MockerToolWindowFactory.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/MockerToolWindowFactory.kt
@@ -52,6 +52,13 @@ class MockerToolWindowFactory : ToolWindowFactory {
         // 기기 드롭다운
         val deviceCombo = JComboBox<String>()
         var devices: List<AdbService.AdbDevice> = emptyList()
+        // true 동안 deviceCombo 의 프로그램적 갱신(removeAllItems/selectedIndex)이 리스너를 발화시키지
+        // 않게 한다 — 같은 기기로 selectDevice/startSession 이 중복 실행되는 것을 막는다.
+        var suppressDeviceEvent = false
+
+        fun runAsync(block: () -> Unit) {
+            Thread(block).apply { isDaemon = true; start() }
+        }
 
         fun loadDevices() {
             Thread {
@@ -63,34 +70,47 @@ class MockerToolWindowFactory : ToolWindowFactory {
                     device.serial to (name?.let { "$it (${device.serial})" } ?: device.serial)
                 }
                 SwingUtilities.invokeLater {
+                    suppressDeviceEvent = true
                     deviceCombo.removeAllItems()
+                    var serialToStart: String? = null
                     if (result.isSuccess) {
                         devices = onlineDevices
                         devices.forEach { deviceCombo.addItem(labels[it.serial]) }
                         val lastSerial = MockerSettings.getInstance().state.lastDeviceSerial
                         val idx = devices.indexOfFirst { it.serial == lastSerial }
-                        if (idx >= 0) {
-                            deviceCombo.selectedIndex = idx
-                            session.selectDevice(devices[idx].serial)
-                        } else if (devices.isNotEmpty()) {
-                            deviceCombo.selectedIndex = 0
-                            session.selectDevice(devices[0].serial)
-                        } else {
-                            session.selectDevice(null)
+                        when {
+                            idx >= 0 -> {
+                                deviceCombo.selectedIndex = idx
+                                serialToStart = devices[idx].serial
+                            }
+                            devices.isNotEmpty() -> {
+                                deviceCombo.selectedIndex = 0
+                                serialToStart = devices[0].serial
+                            }
+                            else -> session.selectDevice(null)
                         }
                     } else {
                         devices = emptyList()
                         session.selectDevice(null)
+                    }
+                    suppressDeviceEvent = false
+                    // 리스너를 억제했으므로 선택된 기기의 세션 시작을 직접(백그라운드로) 트리거한다.
+                    serialToStart?.let { serial ->
+                        session.selectDevice(serial)
+                        runAsync { session.startSession(settings.port) }
                     }
                 }
             }.apply { isDaemon = true; start() }
         }
 
         deviceCombo.addActionListener {
+            if (suppressDeviceEvent) return@addActionListener
             val idx = deviceCombo.selectedIndex
             if (idx >= 0 && idx < devices.size) {
-                session.selectDevice(devices[idx].serial)
-                session.startSession(settings.port)
+                val serial = devices[idx].serial
+                session.selectDevice(serial)
+                // adb.forward 는 블로킹이므로 EDT 밖에서 — 기기 전환 시 IDE 프리징 방지.
+                runAsync { session.startSession(settings.port) }
             }
         }
 
@@ -127,10 +147,11 @@ class MockerToolWindowFactory : ToolWindowFactory {
             }
         })
 
-        // ToolWindow 가시성으로 폴링 start/stop
+        // ToolWindow 가시성으로 폴링 start/stop. startSession 은 블로킹 adb.forward 를 포함하므로
+        // EDT 밖에서 실행한다. stop(removeForward=false) 은 콜백·상태 전이뿐이라 그대로 둔다.
         toolWindow.component.addPropertyChangeListener("showing") { evt ->
             if (evt.newValue == true) {
-                session.startSession(settings.port)
+                runAsync { session.startSession(settings.port) }
             } else {
                 session.stopSession(settings.port, removeForward = false)
             }

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RecordedTableModel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RecordedTableModel.kt
@@ -15,6 +15,10 @@ class RecordedTableModel : AbstractTableModel() {
 
     fun getEntryAt(row: Int): RecordedEntry = entries[row]
 
+    /** method+path(기록 항목의 고유 키)로 행 인덱스를 찾는다. 없으면 -1. */
+    fun indexOfEntry(method: String, path: String): Int =
+        entries.indexOfFirst { it.method == method && it.path == path }
+
     override fun getRowCount(): Int = entries.size
 
     override fun getColumnCount(): Int = columns.size

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RestPanel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/RestPanel.kt
@@ -37,11 +37,13 @@ class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
     private val table = JBTable(tableModel).apply {
         selectionModel.selectionMode = ListSelectionModel.SINGLE_SELECTION
         setShowGrid(false)
+        emptyText.text = "기록된 요청이 없습니다 — 앱에서 네트워크 요청을 보내면 여기에 표시됩니다."
         // 세 컬럼 모두 사용자가 드래그로 폭 조정 가능. preferredWidth 로 기존 기본 폭만 유지한다.
         columnModel.getColumn(2).preferredWidth = 70
     }
 
     private val codeField = JBTextField(6)
+    private val delayField = JBTextField(6)
     private val bodyArea = JBTextArea(5, 40).apply {
         lineWrap = true; wrapStyleWord = true
         margin = JBUI.insets(6)  // 입력란 안쪽 여백 — Status Code 필드의 기본 LaF inset 과 맞춤
@@ -52,12 +54,19 @@ class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
     private val clearAllButton = JButton("전체 Clear")
     private val refreshButton = JButton("새로고침")
 
+    // 편집 패널의 인라인 피드백(성공·실패·안내). 모달 다이얼로그 대신 써서 흐름을 끊지 않는다(WsPanel 과 동일 방식).
+    private val statusLabel = JBLabel("왼쪽에서 항목을 선택하세요")
+
     // 현재 편집 중인 항목 — 폴링이 selection을 초기화해도 유지됨
     private var editingEntry: RecordedEntry? = null
 
-    private val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { r ->
-        Thread(r, "openmocker-poll").apply { isDaemon = true }
-    }
+    // true 동안 선택 리스너가 편집 입력란(코드·지연·본문)을 다시 채우지 않는다.
+    // 폴링/저장 후 선택을 프로그램적으로 복구할 때, 입력 중인 값이 덮어써지는 것을 막는다.
+    private var suppressFieldReload = false
+
+    // WsPanel 과 동일한 생명주기 — start 마다 재생성하고 stop 에서 null 로 비운다. 단일 생성 후 shutdownNow
+    // 하면 재표시(stop→start) 때 죽은 executor 에 schedule 해 예외가 나므로, nullable 로 재생성한다.
+    private var scheduler: ScheduledExecutorService? = null
 
     init {
         border = JBUI.Borders.empty(8)
@@ -77,7 +86,7 @@ class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
     // 박스 아래 8px 간격은 BorderLayout vgap 으로 줘 배너 자체 스타일은 건드리지 않는다.
     private fun buildHeader(): JPanel = JPanel(BorderLayout(0, 8)).apply {
         val banner = InlineBanner(
-            "앱이 보낸 HTTP 요청 목록입니다. 항목을 선택하면 응답(상태 코드·본문)을 원하는 값으로 바꿀 수 있습니다.",
+            "앱이 보낸 HTTP 요청 목록입니다. 항목을 선택하면 응답(상태 코드·본문·지연)을 원하는 값으로 바꿀 수 있습니다.",
             EditorNotificationPanel.Status.Info,
         ).showCloseButton(true)
         banner.setCloseAction {
@@ -105,20 +114,28 @@ class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
         add(JBLabel("Status Code"), gbc)
         gbc.gridx = 1; gbc.weightx = 0.2
         add(codeField, gbc)
+        gbc.gridx = 2; gbc.weightx = 0.0; gbc.insets = Insets(2, 12, 2, 4)
+        add(JBLabel("Delay (ms)"), gbc)
+        gbc.gridx = 3; gbc.weightx = 0.2; gbc.insets = Insets(2, 4, 2, 4)
+        add(delayField, gbc)
 
         gbc.gridx = 0; gbc.gridy = 1; gbc.weightx = 0.0; gbc.fill = GridBagConstraints.NONE
         add(JBLabel("Body"), gbc)
-        gbc.gridx = 1; gbc.weightx = 1.0; gbc.weighty = 1.0; gbc.fill = GridBagConstraints.BOTH
+        gbc.gridx = 1; gbc.gridwidth = 3; gbc.weightx = 1.0; gbc.weighty = 1.0; gbc.fill = GridBagConstraints.BOTH
         add(JBScrollPane(bodyArea), gbc)
 
-        gbc.gridx = 0; gbc.gridy = 2; gbc.gridwidth = 2; gbc.weighty = 0.0
-        gbc.fill = GridBagConstraints.NONE
-        gbc.anchor = GridBagConstraints.EAST; gbc.weightx = 0.0
-        val buttonPanel = JPanel(FlowLayout(FlowLayout.RIGHT, 4, 0)).apply {
-            add(clearMockButton)
-            add(saveButton)
+        gbc.gridx = 0; gbc.gridy = 2; gbc.gridwidth = 4; gbc.weighty = 0.0
+        gbc.fill = GridBagConstraints.HORIZONTAL
+        gbc.anchor = GridBagConstraints.WEST; gbc.weightx = 1.0
+        // 상태 라벨(좌) + 액션 버튼(우). statusLabel 은 흐름을 끊지 않는 인라인 피드백 자리.
+        val footer = JPanel(BorderLayout()).apply {
+            add(JPanel(FlowLayout(FlowLayout.LEFT, 4, 0)).apply { add(statusLabel) }, BorderLayout.WEST)
+            add(JPanel(FlowLayout(FlowLayout.RIGHT, 4, 0)).apply {
+                add(clearMockButton)
+                add(saveButton)
+            }, BorderLayout.EAST)
         }
-        add(buttonPanel, gbc)
+        add(footer, gbc)
     }
 
     private fun wireActions() {
@@ -128,13 +145,18 @@ class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
             if (row < 0) return@addListSelectionListener  // 폴링 리셋 시 editingEntry 유지
             val entry = tableModel.getEntryAt(row)
             editingEntry = entry
-            codeField.text = (entry.mock?.code ?: entry.response.code).toString()
-            bodyArea.text = JsonFormatter.pretty(entry.mock?.body ?: entry.response.body)
-            saveButton.isEnabled = true
+            // 갱신된 항목의 mock 여부를 반영 — 프로그램적 선택 복구에서도 버튼 상태는 맞춘다.
             clearMockButton.isEnabled = entry.mock != null
+            // 선택 복구(폴링/저장 후)일 때는 입력 중인 값을 보존하기 위해 입력란을 다시 채우지 않는다.
+            if (suppressFieldReload) return@addListSelectionListener
+            codeField.text = (entry.mock?.code ?: entry.response.code).toString()
+            delayField.text = (entry.mock?.duration ?: 0L).toString()
+            bodyArea.text = JsonFormatter.pretty(entry.mock?.body ?: entry.response.body)
+            saveButton.isEnabled = false  // 방금 불러온 값 = 미저장 변경 없음
+            statusLabel.text = ""         // 선택 전 안내 제거
         }
 
-        // body/code 수정 시 편집 중인 항목이 있으면 저장 버튼 활성화
+        // body/code/delay 수정 시 편집 중인 항목이 있으면 저장 버튼 활성화
         val editListener = object : DocumentListener {
             override fun insertUpdate(e: DocumentEvent) = onEdit()
             override fun removeUpdate(e: DocumentEvent) = onEdit()
@@ -145,67 +167,150 @@ class RestPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
         }
         bodyArea.document.addDocumentListener(editListener)
         codeField.document.addDocumentListener(editListener)
+        delayField.document.addDocumentListener(editListener)
+
+        // 입력란에서 Enter 로 바로 저장(본문은 줄바꿈이라 제외).
+        codeField.addActionListener { if (saveButton.isEnabled) saveButton.doClick() }
+        delayField.addActionListener { if (saveButton.isEnabled) saveButton.doClick() }
 
         saveButton.addActionListener {
             val entry = editingEntry ?: return@addActionListener
+            // 입력 읽기·검증은 EDT 에서(필드 접근). 검증 실패는 인라인 상태로 알린다.
             val raw = codeField.text.trim()
             val code = raw.toIntOrNull()
             if (code == null) {
-                Messages.showErrorDialog(this, "Status Code 는 숫자여야 합니다: '$raw'", "Mock 저장 실패")
+                statusLabel.text = "✗ Status Code 는 숫자여야 합니다: '$raw'"
+                return@addActionListener
+            }
+            val delayRaw = delayField.text.trim().ifEmpty { "0" }
+            val duration = delayRaw.toLongOrNull()
+            if (duration == null || duration < 0) {
+                statusLabel.text = "✗ Delay 는 0 이상의 숫자여야 합니다: '$delayRaw'"
                 return@addActionListener
             }
             val body = bodyArea.text
-            val result = client.upsertMock(MockRequest(method = entry.method, path = entry.path, code = code, body = body))
-            if (reportIfFailed(result, "Mock 저장 실패")) return@addActionListener
-            refresh()
+            statusLabel.text = "저장 중…"
+            // HTTP 는 백그라운드에서 — EDT 블로킹(프리징) 방지. 결과·후속 refresh 만 처리.
+            runAsync {
+                val result = client.upsertMock(
+                    MockRequest(method = entry.method, path = entry.path, code = code, body = body, duration = duration)
+                )
+                SwingUtilities.invokeLater {
+                    if (result.isFailure) {
+                        statusLabel.text = "✗ 저장 실패: ${result.exceptionOrNull()?.message}"
+                    } else {
+                        statusLabel.text = "● 저장됨"
+                        saveButton.isEnabled = false
+                    }
+                }
+                // 성공 시에만 갱신 — 선택을 그대로 복구하고, 리스너가 갱신된(mocked) 항목을 읽어
+                // Mock 해제 버튼을 활성화한다. refresh 는 성공 시 statusLabel 을 건드리지 않는다.
+                if (result.isSuccess) refresh()
+            }
         }
 
         clearMockButton.addActionListener {
             val entry = editingEntry ?: return@addActionListener
-            val result = client.clearMock(method = entry.method, path = entry.path)
-            if (reportIfFailed(result, "Mock 해제 실패")) return@addActionListener
-            editingEntry = null
-            clearMockButton.isEnabled = false
-            refresh()
+            statusLabel.text = "Mock 해제 중…"
+            runAsync {
+                val result = client.clearMock(method = entry.method, path = entry.path)
+                SwingUtilities.invokeLater {
+                    if (result.isFailure) {
+                        statusLabel.text = "✗ Mock 해제 실패: ${result.exceptionOrNull()?.message}"
+                    } else {
+                        statusLabel.text = "● Mock 해제됨"
+                        editingEntry = null
+                        clearMockButton.isEnabled = false
+                        saveButton.isEnabled = false
+                    }
+                }
+                if (result.isSuccess) refresh()
+            }
         }
 
         clearAllButton.addActionListener {
-            val result = client.clearAll()
-            if (reportIfFailed(result, "전체 Clear 실패")) return@addActionListener
-            editingEntry = null
-            saveButton.isEnabled = false
-            clearMockButton.isEnabled = false
-            refresh()
+            // 파괴적·비가역 작업 — 확인을 받는다.
+            val answer = Messages.showYesNoDialog(
+                this,
+                "기록된 요청과 설정된 mock 을 모두 삭제합니다. 되돌릴 수 없습니다. 계속할까요?",
+                "전체 Clear",
+                Messages.getWarningIcon(),
+            )
+            if (answer != Messages.YES) return@addActionListener
+            statusLabel.text = "전체 삭제 중…"
+            runAsync {
+                val result = client.clearAll()
+                SwingUtilities.invokeLater {
+                    if (result.isFailure) {
+                        statusLabel.text = "✗ 전체 Clear 실패: ${result.exceptionOrNull()?.message}"
+                    } else {
+                        statusLabel.text = "● 전체 삭제됨"
+                        editingEntry = null
+                        saveButton.isEnabled = false
+                        clearMockButton.isEnabled = false
+                    }
+                }
+                if (result.isSuccess) refresh()
+            }
         }
 
-        refreshButton.addActionListener { refresh() }
+        refreshButton.addActionListener { runAsync { refresh() } }
+    }
+
+    private fun runAsync(action: () -> Unit) {
+        Thread(action).apply { isDaemon = true; start() }
     }
 
     fun startPolling() {
+        if (scheduler != null) return  // 중복 start(이중 startSession) 시 폴링 루프 중복 생성 방지
         val intervalMs = MockerSettings.getInstance().state.pollIntervalMs.toLong()
-        scheduler.scheduleAtFixedRate(::refresh, 0L, intervalMs, TimeUnit.MILLISECONDS)
+        val executor = Executors.newSingleThreadScheduledExecutor { r ->
+            Thread(r, "openmocker-poll").apply { isDaemon = true }
+        }
+        scheduler = executor
+        executor.scheduleAtFixedRate(::refresh, 0L, intervalMs, TimeUnit.MILLISECONDS)
     }
 
     /**
-     * [ControlClient] 호출 [Result] 가 실패면 에러 다이얼로그를 띄우고 true 를 반환한다.
-     * 제어 서버 미연결(adb forward 없음)·비2xx 응답 등 실패가 조용히 묻히지 않도록 한다.
+     * 기록 목록을 갱신한다. 폴링 스케줄러와 버튼 핸들러가 모두 백그라운드 스레드에서 호출한다.
+     * 실패는 인라인 상태로 알린다(연결 끊김 등이 조용히 묻히지 않도록). 성공 시에는 statusLabel 을
+     * 건드리지 않아 직전 액션 피드백("● 저장됨" 등)을 덮지 않는다.
      */
-    private fun reportIfFailed(result: Result<Unit>, title: String): Boolean {
-        val cause = result.exceptionOrNull() ?: return false
-        Messages.showErrorDialog(this, cause.message ?: "알 수 없는 오류", title)
-        return true
-    }
-
     private fun refresh() {
         val result = client.getRecorded()
         if (result.isSuccess) {
+            val entries = result.getOrThrow()
             SwingUtilities.invokeLater {
-                tableModel.update(result.getOrThrow())
+                tableModel.update(entries)
+                restoreSelection()
+            }
+        } else {
+            SwingUtilities.invokeLater {
+                statusLabel.text = "✗ 갱신 실패: ${result.exceptionOrNull()?.message}"
             }
         }
     }
 
+    /**
+     * 갱신으로 풀린 선택을, 편집 중이던 항목([editingEntry])의 method+path 키로 같은 행에 복구한다.
+     * 테이블 갱신과 같은 EDT 사이클 안에서 즉시 일어나므로 사용자에게는 선택이 그대로 유지되는 것처럼
+     * 보인다(깜빡임 없음). 인덱스가 아닌 키로 복구하므로 행이 추가·삭제·재정렬돼도 올바른 항목을 다시 고른다.
+     * [suppressFieldReload] 로 선택 리스너의 입력란 갱신은 건너뛰어 입력 중인 값을 보존한다.
+     */
+    private fun restoreSelection() {
+        val target = editingEntry ?: return
+        val row = tableModel.indexOfEntry(target.method, target.path)
+        if (row < 0) return
+        suppressFieldReload = true
+        try {
+            table.selectionModel.setSelectionInterval(row, row)
+        } finally {
+            suppressFieldReload = false
+        }
+    }
+
     fun stopPolling() {
-        scheduler.shutdownNow()
+        scheduler?.shutdownNow()
+        scheduler = null
     }
 }

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/WsPanel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/WsPanel.kt
@@ -41,6 +41,7 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
         selectionModel.selectionMode = ListSelectionModel.SINGLE_SELECTION
         setShowGrid(false)
         tableHeader.reorderingAllowed = false
+        emptyText.text = "수신된 메시지가 없습니다 — 아래에서 페이로드를 보내면 여기에 기록됩니다."
     }
 
     // 폴링이 항목을 갱신하며 selection 을 복원할 때는, 그 프로그램적 선택이 payloadArea 를 덮지 않게 막는다.


### PR DESCRIPTION
## Meta

PR Type: feature

Closes #159

## 문제/신규 기능 설명

플러그인 REST 탭에서는 mock 응답의 상태 코드·본문만 편집 가능하고 **응답 지연(delay)은 설정할 수 없었다.**
지연은 제어 서버 계약(`MockRequest.duration`)과 양쪽 클라이언트(OkHttp/Ktor) 적용부에 이미 구현돼 있었으나
플러그인 UI 입력란만 없는 상태였다. 입력란을 추가해 플러그인만으로 타임아웃·로딩 시나리오를 모킹할 수 있게 한다.

작업·검증 과정에서 발견한 UX 결함과 서버 견고성 갭도 함께 정리한다.

## 적용 버전

0.1.0-beta1

## 원인

신규 기능 — 해당 없음 (단, 함께 수정한 항목 중 폴링 생명주기·서버 무응답은 기존 버그로, 아래 "수정/구현" 참고)

## 수정/구현

**기능 (REST Delay)**
- 편집 패널에 `Delay (ms)` 입력란 추가(Status Code 와 같은 행), 선택 시 기존 `mock.duration` prefill
- 저장 시 검증(빈 값=0, 음수·비숫자 거부) 후 `MockRequest(duration=)` 전송
- 계약·`ControlClient` 직렬화는 기존 그대로 (UI만 배선)

**UX 개선 (plugin)**
| 항목 | 내용 |
|---|---|
| EDT 블로킹 제거 | 저장·Mock 해제·전체 Clear·새로고침·기기 선택의 블로킹 HTTP/adb 호출을 백그라운드 스레드로 이동 → IDE 프리징 방지 |
| 안전장치 | 전체 Clear 에 확인 다이얼로그(비가역 작업) |
| 피드백 | 저장 성공 인라인 표시, 에러를 모달→인라인 상태로 통일, 빈 상태 안내, Enter=저장 |
| 선택 유지 | 저장/폴링 후 method+path 키로 선택 복구, Mock 해제 버튼 상태 반영 |

**버그 수정**
- RestPanel 폴링 생명주기: stop→start(툴윈도우 재표시) 시 죽은 executor 재사용 예외 → nullable 재생성, 중복 폴링 가드, 기기 콤보 중복 트리거 제거
- `:lib` 제어 서버: half-open 커넥션이 `readHttpRequest` 블로킹 read 에서 IO 스레드를 무한 점유해 서버가 무응답이 되는 문제 → 커넥션당 소켓 read timeout(10s) 추가, 타임아웃은 조용히 종료

**리뷰 포인트**
- `RestPanel` 의 `runAsync` 도입과 `suppressFieldReload`/`restoreSelection` 의 폴링 중 입력값 보존 로직
- `ControlServer` 의 `SOCKET_READ_TIMEOUT_MS` 와 `SocketTimeoutException` 조용한 종료 경로
