### PR TITLE
플러그인 SpoonOpenMocker 리브랜딩 (타이틀·아이콘)

### DIFF
--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/settings/MockerConfigurable.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/settings/MockerConfigurable.kt
@@ -9,7 +9,7 @@ import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.panel
 
 /**
- * Settings/Preferences > Tools > OpenMocker 화면. [MockerSettings] 값을 노출·편집한다.
+ * Settings/Preferences > Tools > SpoonOpenMocker 화면. [MockerSettings] 값을 노출·편집한다.
  *
  * UI 는 플랫폼 번들 Kotlin UI DSL 만 쓴다(외부 의존성 0 원칙). 각 입력은 [MockerSettings.state] 의
  * 필드에 직접 바인딩되므로, DSL 이 reset/isModified/apply 를 자동 처리한다. 값의 유효 범위만
@@ -18,7 +18,7 @@ import com.intellij.ui.dsl.builder.panel
  * `lastDeviceSerial` 은 사용자가 직접 입력하는 값이 아니라 기기 드롭다운이 갱신하는 값이라 이 화면엔
  * 노출하지 않는다.
  */
-class MockerConfigurable : BoundConfigurable("OpenMocker") {
+class MockerConfigurable : BoundConfigurable("SpoonOpenMocker") {
 
     private val state get() = MockerSettings.getInstance().state
 

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/StatusBar.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/StatusBar.kt
@@ -41,7 +41,7 @@ class StatusBar(private val project: Project) : JPanel(FlowLayout(FlowLayout.LEF
     private fun notifyError(message: String) {
         NotificationGroupManager.getInstance()
             .getNotificationGroup("OpenMocker")
-            .createNotification("OpenMocker 연결 실패", message, NotificationType.ERROR)
+            .createNotification("SpoonOpenMocker 연결 실패", message, NotificationType.ERROR)
             .notify(project)
     }
 }

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
     <id>net.spooncast.openmocker.plugin</id>
-    <name>OpenMocker</name>
+    <name>SpoonOpenMocker</name>
     <vendor>Spooncast</vendor>
     <description><![CDATA[
         Desktop control panel for the OpenMocker library — edit REST mocks and fire
@@ -29,8 +29,9 @@
         <projectService serviceImplementation="net.spooncast.openmocker.plugin.session.MockerSession" />
         <!-- 빈 ToolWindow 골격. REST/WS 패널은 T14/T15 에서 채운다. -->
         <toolWindow
-            id="OpenMocker"
+            id="SpoonOpenMocker"
             anchor="right"
+            icon="/icons/spoonOpenMocker.svg"
             factoryClass="net.spooncast.openmocker.plugin.ui.MockerToolWindowFactory" />
 
         <notificationGroup id="OpenMocker" displayType="BALLOON" />
@@ -39,7 +40,7 @@
         <applicationConfigurable
             parentId="tools"
             id="net.spooncast.openmocker.settings"
-            displayName="OpenMocker"
+            displayName="SpoonOpenMocker"
             instance="net.spooncast.openmocker.plugin.settings.MockerConfigurable" />
     </extensions>
 </idea-plugin>

--- a/plugin/src/main/resources/META-INF/pluginIcon.svg
+++ b/plugin/src/main/resources/META-INF/pluginIcon.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="20" cy="20" r="18" fill="#2D6CDF"/>
+  <path d="M11.5 28V13L20 22L28.5 13V28" stroke="#FFFFFF" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/plugin/src/main/resources/META-INF/pluginIcon_dark.svg
+++ b/plugin/src/main/resources/META-INF/pluginIcon_dark.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="20" cy="20" r="18" fill="#4C8DFF"/>
+  <path d="M11.5 28V13L20 22L28.5 13V28" stroke="#1E1F22" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/plugin/src/main/resources/icons/spoonOpenMocker.svg
+++ b/plugin/src/main/resources/icons/spoonOpenMocker.svg
@@ -1,0 +1,4 @@
+<svg width="13" height="13" viewBox="0 0 13 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="6.5" cy="6.5" r="5.5" stroke="#6E6E6E" stroke-width="1"/>
+  <path d="M3.8 9V4.2L6.5 7L9.2 4.2V9" stroke="#6E6E6E" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/plugin/src/main/resources/icons/spoonOpenMocker_dark.svg
+++ b/plugin/src/main/resources/icons/spoonOpenMocker_dark.svg
@@ -1,0 +1,4 @@
+<svg width="13" height="13" viewBox="0 0 13 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="6.5" cy="6.5" r="5.5" stroke="#AFB1B3" stroke-width="1"/>
+  <path d="M3.8 9V4.2L6.5 7L9.2 4.2V9" stroke="#AFB1B3" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Meta

PR Type: feature

## 문제/신규 기능 설명

데스크톱 플러그인의 사용자 노출 이름을 OpenMocker → **SpoonOpenMocker** 로 바꾸고,
지금까지 IntelliJ 기본값을 쓰던 아이콘을 신규로 추가한다.

## 적용 버전

플러그인 0.1.0-beta2 (라이브러리 버전 무관 — 해당 없음)

## 원인

신규 기능 — 해당 없음

## 수정/구현

- **타이틀(노출 5곳)** — plugin name, toolWindow 제목, 설정 페이지 `displayName` /
  `BoundConfigurable`, 알림 제목을 `SpoonOpenMocker` 로 변경.
- **아이콘 신규 추가** — "원 안에 M" 디자인, 라이트·다크 변형.

  | 용도 | 파일 | 사양 |
  |---|---|---|
  | 툴윈도우 탭 | `icons/spoonOpenMocker.svg`(+`_dark`) | 13×13 모노크롬 라인 |
  | 플러그인 목록 | `META-INF/pluginIcon.svg`(+`_dark`) | 40×40 색 채움 |

  `plugin.xml` toolWindow 에 `icon="/icons/spoonOpenMocker.svg"` 연결.
- 리뷰 포인트: **내부 식별자는 의도적으로 유지** — 플러그인 고유 `<id>`,
  `@State`/`Storage` 영속화 키, `notificationGroup id="OpenMocker"`(+`getNotificationGroup` 매칭쌍).
  바꾸면 다른 플러그인 취급·기존 설정 유실 위험.
