### PR TITLE
[Plugin] GUI로 띄운 Android Studio에서 기기 드롭다운이 비는 문제 — adb 경로 탐색 개선

### DIFF
--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/adb/AdbService.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/adb/AdbService.kt
@@ -12,8 +12,10 @@ import java.util.concurrent.TimeUnit
  *
  * 프로세스 실행(부수효과)과 출력 파싱(순수)을 분리한다. 파싱은 [parseDevices]/[parseForwards] 의
  * 순수 함수로 두어 실제 adb 없이 출력 문자열만으로 단위 테스트할 수 있고, 프로세스 실행은 [runner]
- * seam 으로 주입해 기본값은 ProcessBuilder, 테스트는 가짜 러너를 끼울 수 있다. adb 탐색의 env 조회도
- * [env] seam 으로 주입한다.
+ * seam 으로 주입해 기본값은 ProcessBuilder, 테스트는 가짜 러너를 끼울 수 있다. adb 탐색에 닿는 외부
+ * 상태 — env 조회([env]), 파일 존재([fileExists]), 설정 override([settingsAdbPath]), 홈 디렉토리
+ * ([userHome]) · OS 이름([osName]) — 도 모두 seam 으로 주입해 실제 파일시스템 없이 탐색 로직을 단위
+ * 테스트할 수 있다.
  *
  * 운영 시 [forward] 는 기기 loopback 의 제어 서버 포트(기본 8099)를 데스크톱 loopback 으로 노출해
  * [ControlClient][net.spooncast.openmocker.plugin.net.ControlClient] 가 접속할 수 있게 한다.
@@ -22,6 +24,10 @@ class AdbService(
     private val env: (String) -> String? = System::getenv,
     private val timeout: Long = DEFAULT_TIMEOUT_SECONDS,
     private val runner: (List<String>) -> ProcessResult = { runProcess(it, timeout) },
+    private val fileExists: (String) -> Boolean = { File(it).isFile },
+    private val settingsAdbPath: () -> String? = { null },
+    private val userHome: () -> String? = { System.getProperty("user.home") },
+    private val osName: () -> String = { System.getProperty("os.name").orEmpty() },
 ) {
     /** 프로세스 1회 실행 결과. [exitCode] 가 null 이면 타임아웃으로 강제 종료된 것이다. */
     data class ProcessResult(
@@ -89,19 +95,63 @@ class AdbService(
         exec(listOf(resolveAdb(), "-s", serial, "shell", "getprop", prop)).trim()
 
     /**
-     * adb 실행파일 경로를 결정한다. `ANDROID_HOME` → `ANDROID_SDK_ROOT` 의 `platform-tools/adb`
-     * 가 실재하면 그 절대경로를, 둘 다 없으면 `PATH` 위임을 기대하고 `adb` 를 반환한다. 후보 SDK 가
-     * 지정됐는데 실행파일이 없으면 [AdbException] 으로 실패시킨다(오타·미설치 조기 발견).
+     * adb 실행파일 경로를 우선순위대로 결정한다:
+     * 1. 설정 override([settingsAdbPath]) — 사용자가 Settings 에 지정한 SDK 루트.
+     * 2. `ANDROID_HOME` → `ANDROID_SDK_ROOT` 환경변수.
+     * 3. OS 표준 기본 설치 위치([standardSdkRoots]) — GUI 로 띄운 IDE 처럼 env 가 없는 환경 대비.
+     * 4. 위 후보가 모두 없으면 `PATH` 위임을 기대하고 `adb`(Windows `adb.exe`)를 반환.
+     *
+     * override·env 처럼 **명시적으로 지정된** SDK 루트 아래에 실행파일이 없으면 [AdbException] 으로
+     * 실패시킨다(오타·미설치 조기 발견). 표준 위치는 "있으면 쓰는" 후보라 없으면 다음 단계로 넘어간다.
      */
     private fun resolveAdb(): String {
+        settingsAdbPath()?.takeIf { it.isNotBlank() }?.let { home ->
+            val candidate = adbUnder(home)
+            if (fileExists(candidate)) return candidate
+            throw AdbException("설정된 SDK 경로 아래에서 adb 실행파일을 찾지 못했습니다: $candidate")
+        }
         for (key in SDK_ENV_KEYS) {
             val home = env(key)?.takeIf { it.isNotBlank() } ?: continue
-            val candidate = File(File(home, "platform-tools"), adbExecutableName())
-            if (candidate.isFile) return candidate.absolutePath
-            throw AdbException("$key=$home 아래에서 adb 실행파일을 찾지 못했습니다: ${candidate.absolutePath}")
+            val candidate = adbUnder(home)
+            if (fileExists(candidate)) return candidate
+            throw AdbException("$key=$home 아래에서 adb 실행파일을 찾지 못했습니다: $candidate")
+        }
+        for (home in standardSdkRoots()) {
+            val candidate = adbUnder(home)
+            if (fileExists(candidate)) return candidate
         }
         return adbExecutableName()
     }
+
+    /** SDK 루트 아래 `platform-tools/adb`(Windows `adb.exe`)의 절대경로 문자열. */
+    private fun adbUnder(sdkHome: String): String =
+        File(File(sdkHome, "platform-tools"), adbExecutableName()).absolutePath
+
+    /**
+     * OS 표준 Android SDK 설치 위치 후보(우선순위 순). [userHome]/[osName]/[env] seam 에만 의존해
+     * 실제 FS 없이도 결정적이다. 후보를 못 만들면(홈 디렉토리 미상 등) 빈 리스트.
+     * - macOS: `~/Library/Android/sdk`
+     * - Linux: `~/Android/Sdk`
+     * - Windows: `%LOCALAPPDATA%\Android\Sdk`
+     */
+    private fun standardSdkRoots(): List<String> {
+        if (isWindows()) {
+            val localAppData = env("LOCALAPPDATA")?.takeIf { it.isNotBlank() } ?: return emptyList()
+            return listOf(File(File(localAppData, "Android"), "Sdk").path)
+        }
+        val home = userHome()?.takeIf { it.isNotBlank() } ?: return emptyList()
+        return if (isMac()) {
+            listOf(File(File(File(home, "Library"), "Android"), "sdk").path)
+        } else {
+            listOf(File(File(home, "Android"), "Sdk").path)
+        }
+    }
+
+    private fun isWindows(): Boolean = osName().startsWith("Windows", ignoreCase = true)
+
+    private fun isMac(): Boolean = osName().startsWith("Mac", ignoreCase = true)
+
+    private fun adbExecutableName(): String = if (isWindows()) "adb.exe" else "adb"
 
     /** 프로세스를 실행하고 비정상 종료/타임아웃을 [AdbException] 으로 변환한 뒤 stdout 을 돌려준다. */
     private fun exec(command: List<String>): String {
@@ -147,9 +197,6 @@ class AdbService(
 
         /** adb 탐색 시 우선순위대로 조회하는 SDK 루트 env 키. */
         private val SDK_ENV_KEYS = listOf("ANDROID_HOME", "ANDROID_SDK_ROOT")
-
-        private fun adbExecutableName(): String =
-            if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)) "adb.exe" else "adb"
 
         /** 실제 프로세스를 ProcessBuilder 로 실행하는 기본 runner. 타임아웃 시 [ProcessResult.exitCode] 가 null. */
         private fun runProcess(command: List<String>, timeout: Long): ProcessResult {

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/session/MockerSession.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/session/MockerSession.kt
@@ -10,7 +10,10 @@ enum class ConnectionState { IDLE, FORWARDING, CONNECTED, ERROR }
 
 @Service(Service.Level.PROJECT)
 class MockerSession(@Suppress("UNUSED_PARAMETER") project: Project) {
-    private val adb = AdbService()
+    // settingsAdbPath 는 람다로 넘겨 매 adb 호출 시 최신 설정값을 읽는다(IDE 재시작 없이 경로 변경 반영).
+    private val adb = AdbService(
+        settingsAdbPath = { MockerSettings.getInstance().state.sdkPath.takeIf { it.isNotBlank() } },
+    )
     private val settings get() = MockerSettings.getInstance().state
 
     var connectionState: ConnectionState = ConnectionState.IDLE

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/settings/MockerConfigurable.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/settings/MockerConfigurable.kt
@@ -4,8 +4,11 @@ import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.dsl.builder.COLUMNS_LARGE
 import com.intellij.ui.dsl.builder.bindIntText
 import com.intellij.ui.dsl.builder.bindSelected
+import com.intellij.ui.dsl.builder.bindText
+import com.intellij.ui.dsl.builder.columns
 import com.intellij.ui.dsl.builder.panel
 
 /**
@@ -36,6 +39,12 @@ class MockerConfigurable : BoundConfigurable("OpenMocker") {
         row {
             cell(JBCheckBox("기기 선택 시 자동으로 adb forward 설정"))
                 .bindSelected(state::autoForward)
+        }
+        row("Android SDK path:") {
+            textField()
+                .columns(COLUMNS_LARGE)
+                .bindText(state::sdkPath)
+                .comment("비워두면 ANDROID_HOME·표준 위치를 자동 탐색합니다. 자동 탐색이 실패할 때만 SDK 루트 경로를 지정하세요 (예: ~/Library/Android/sdk).")
         }
     }
 

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/settings/MockerSettings.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/settings/MockerSettings.kt
@@ -31,12 +31,16 @@ class MockerSettings : PersistentStateComponent<MockerSettings.State> {
      * - [lastDeviceSerial]: 마지막으로 선택한 adb 기기 serial. 미선택 상태는 빈 문자열.
      * - [pollIntervalMs]: REST 기록 테이블 폴링 주기(ms, 기본 [DEFAULT_POLL_INTERVAL_MS]).
      * - [autoForward]: 기기 선택 시 자동으로 adb forward 를 설정할지 여부.
+     * - [sdkPath]: Android SDK 루트 경로 override. 빈 문자열이면 미지정(env·표준 위치 자동 탐색).
+     *   지정 시 [AdbService][net.spooncast.openmocker.plugin.adb.AdbService] 가 그 아래
+     *   `platform-tools/adb` 를 최우선으로 찾는다(자동 탐색이 실패하는 비표준 설치 탈출구).
      */
     data class State(
         var port: Int = DEFAULT_PORT,
         var lastDeviceSerial: String = "",
         var pollIntervalMs: Int = DEFAULT_POLL_INTERVAL_MS,
         var autoForward: Boolean = true,
+        var sdkPath: String = "",
     )
 
     private var state = State()

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/MockerToolWindowFactory.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/MockerToolWindowFactory.kt
@@ -64,6 +64,8 @@ class MockerToolWindowFactory : ToolWindowFactory {
             Thread {
                 val result = session.loadDevices()
                 val onlineDevices = result.getOrNull()?.filter { it.isOnline }.orEmpty()
+                // 실패 사유(adb 미탐색 등)는 EDT 밖에서 미리 추출해 두고, 아래 실패 분기에서 노출한다.
+                val failureMessage = result.exceptionOrNull()?.message
                 // 기기명은 EDT 밖에서 미리 조회한다. "<기기명> (<serial>)" 형식, 실패 시 serial 만.
                 val labels = onlineDevices.associate { device ->
                     val name = session.deviceName(device.serial).getOrNull()?.takeIf { it.isNotBlank() }
@@ -92,6 +94,12 @@ class MockerToolWindowFactory : ToolWindowFactory {
                     } else {
                         devices = emptyList()
                         session.selectDevice(null)
+                        // 빈 드롭다운에 사유까지 묻히지 않도록, adb 미탐색 등 실패 사유를 StatusBar·알림으로 노출한다.
+                        statusBar.update(
+                            ConnectionState.ERROR,
+                            failureMessage
+                                ?: "adb 를 찾을 수 없습니다 — Settings > Tools > OpenMocker 에서 Android SDK 경로를 지정하세요.",
+                        )
                     }
                     suppressDeviceEvent = false
                     // 리스너를 억제했으므로 선택된 기기의 세션 시작을 직접(백그라운드로) 트리거한다.

--- a/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/adb/AdbServiceTest.kt
+++ b/plugin/src/test/kotlin/net/spooncast/openmocker/plugin/adb/AdbServiceTest.kt
@@ -124,11 +124,13 @@ class AdbServiceTest {
 
     @Test
     fun `resolveAdb falls back to PATH when no sdk env set`() {
-        // SDK env 가 없으면 PATH 위임을 기대하고 "adb" 만으로 실행 — 명령 첫 토큰으로 확인한다.
+        // env·override·표준 위치가 모두 없으면 PATH 위임을 기대하고 "adb" 만으로 실행 — 명령 첫 토큰으로
+        // 확인한다. fileExists 를 항상 false 로 주입해 호스트의 실제 SDK 설치 유무와 무관하게 결정적이다.
         var captured: List<String>? = null
         val service = AdbService(
             env = { null },
             runner = { cmd -> captured = cmd; ProcessResult(0, "List of devices attached\n", "") },
+            fileExists = { false },
         )
 
         val result = service.devices()
@@ -138,11 +140,84 @@ class AdbServiceTest {
     }
 
     @Test
+    fun `resolveAdb uses standard macOS sdk location when no env set`() {
+        // env 가 없어도 macOS 표준 위치(~/Library/Android/sdk)에 adb 가 있으면 그 절대경로를 쓴다.
+        val expected = "/Users/test/Library/Android/sdk/platform-tools/adb"
+        var captured: List<String>? = null
+        val service = AdbService(
+            env = { null },
+            runner = { cmd -> captured = cmd; ProcessResult(0, "List of devices attached\n", "") },
+            fileExists = { it == expected },
+            userHome = { "/Users/test" },
+            osName = { "Mac OS X" },
+        )
+
+        val result = service.devices()
+
+        assertTrue(result.isSuccess)
+        assertEquals(expected, captured?.first())
+    }
+
+    @Test
+    fun `resolveAdb uses standard Linux sdk location when no env set`() {
+        val expected = "/home/test/Android/Sdk/platform-tools/adb"
+        var captured: List<String>? = null
+        val service = AdbService(
+            env = { null },
+            runner = { cmd -> captured = cmd; ProcessResult(0, "List of devices attached\n", "") },
+            fileExists = { it == expected },
+            userHome = { "/home/test" },
+            osName = { "Linux" },
+        )
+
+        service.devices()
+
+        assertEquals(expected, captured?.first())
+    }
+
+    @Test
+    fun `resolveAdb prefers settings override over env and standard location`() {
+        // 모든 후보가 존재(fileExists=true)해도 override 가 최우선이어야 한다.
+        val expected = "/custom/sdk/platform-tools/adb"
+        var captured: List<String>? = null
+        val service = AdbService(
+            env = { key -> if (key == "ANDROID_HOME") "/env/sdk" else null },
+            runner = { cmd -> captured = cmd; ProcessResult(0, "List of devices attached\n", "") },
+            fileExists = { true },
+            settingsAdbPath = { "/custom/sdk" },
+            userHome = { "/home/test" },
+            osName = { "Linux" },
+        )
+
+        service.devices()
+
+        assertEquals(expected, captured?.first())
+    }
+
+    @Test
+    fun `resolveAdb fails when settings override set but executable missing`() {
+        // override SDK 경로 아래에 adb 가 없으면 조기 실패(오타·미설치 발견).
+        val service = AdbService(
+            env = { null },
+            runner = { ProcessResult(0, "", "") },
+            fileExists = { false },
+            settingsAdbPath = { "/custom/sdk" },
+        )
+
+        val result = service.devices()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is AdbException)
+        assertTrue(result.exceptionOrNull()!!.message!!.contains("/custom/sdk"))
+    }
+
+    @Test
     fun `resolveAdb fails when sdk env set but executable missing`() {
         // ANDROID_HOME 가 가리키는 곳에 platform-tools/adb 가 없으면 조기 실패(오타·미설치 발견).
         val service = AdbService(
             env = { key -> if (key == "ANDROID_HOME") "/no/such/sdk/path" else null },
             runner = { ProcessResult(0, "", "") },
+            fileExists = { false },
         )
 
         val result = service.devices()
@@ -160,6 +235,7 @@ class AdbServiceTest {
         val service = AdbService(
             env = { null },
             runner = { cmd -> captured = cmd; ProcessResult(0, "", "") },
+            fileExists = { false },
         )
 
         val result = service.forward(serial = "emulator-5554", port = 8099)
@@ -177,6 +253,7 @@ class AdbServiceTest {
         val service = AdbService(
             env = { null },
             runner = { cmd -> captured = cmd; ProcessResult(0, "", "") },
+            fileExists = { false },
         )
 
         service.removeForward(serial = "emulator-5554", port = 8099)


### PR DESCRIPTION
## Meta

PR Type: bug-fix

Closes #161

## 문제/신규 기능 설명

GUI(Finder/Dock/Toolbox)로 띄운 Android Studio 에서 기기 드롭다운이 빈 채로 뜨고
사유도 노출되지 않았다.

- 재현: Toolbox/Finder 로 AS 실행(터미널 아님) → OpenMocker Tool Window → 기기 목록 비어 있음, 알림 없음.
- 영향: macOS/Toolbox 사용자 대부분에게 재현되는 공통 실패 모드라 플러그인 첫 사용을 가로막음.

## 적용 버전

플러그인 0.1.0-beta2

## 원인

GUI 로 띄운 IDE 프로세스에는 `ANDROID_HOME`·`ANDROID_SDK_ROOT` 가 unset 이고 PATH 도
최소(`/usr/bin:/bin:/usr/sbin:/sbin`)라 platform-tools 가 없다. 기존 `resolveAdb()` 는
두 env 와 PATH 에만 의존해 bare `"adb"` 를 반환 → 최소 PATH 에서 실행 불가 →
`devices()` 가 `Result.failure` 로 흡수 → 드롭다운이 빈 채 사유가 묻혔다.

## 수정/구현

- **A. 표준 SDK 위치 폴백** (`AdbService`) — `resolveAdb()` 탐색 순서를
  `override → ANDROID_HOME → ANDROID_SDK_ROOT → OS 표준 위치 → PATH` 로 확장.
  표준 위치: macOS `~/Library/Android/sdk`, Linux `~/Android/Sdk`, Windows `%LOCALAPPDATA%\Android\Sdk`.
- **B. 실패 사유 노출** (`MockerToolWindowFactory`) — `loadDevices()` 실패 분기에서
  예외 메시지를 `StatusBar(ERROR)` + `OpenMocker` 알림으로 노출(빈 드롭다운 + 무음 제거).
- **C. 경로 override** (`MockerSettings` / `MockerConfigurable`) — "Android SDK path"
  설정란 추가(비표준 설치 탈출구). `MockerSession` 이 람다로 주입해 재시작 없이 반영.
- **테스트** — `fileExists`·`settingsAdbPath`·`userHome`·`osName` seam 으로 표준위치(mac/linux)·
  override 우선·override 미존재 케이스 추가. 기존 케이스는 `fileExists` 주입으로 호스트 SDK
  설치 유무와 무관하게 결정적으로 보정.

리뷰 포인트:
- `resolveAdb()` 우선순위 — override·env 는 지정됐는데 파일 없으면 `AdbException`(조기 실패), 표준위치는 "있으면 쓰는" 후보라 없으면 다음 단계로 넘어감.
- 이번 케이스(GUI AS)는 A 의 macOS 표준위치 폴백만으로 해결.
