### PR TITLE
WebSocket 탭 UI 문구 통일 (Event Injection → WebSocket, 수신 Clear → 전체 Clear)

### DIFF
--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/EventRecordedTableModel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/EventRecordedTableModel.kt
@@ -4,7 +4,7 @@ import net.spooncast.openmocker.plugin.net.RecordedMessage
 import javax.swing.table.AbstractTableModel
 
 /**
- * Event Injection 탭의 수신 메시지 표 모델. REST 탭의 [RecordedTableModel] 과 같은 골격이되,
+ * WebSocket 탭의 수신 메시지 표 모델. REST 탭의 [RecordedTableModel] 과 같은 골격이되,
  * 컬럼은 단일("수신 메시지")이다. 셀 값은 payload 를 한 줄로 접은 미리보기로, 행 선택 시
  * 원문([getMessageAt])을 입력란에 복사한다.
  */

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/MockerToolWindowFactory.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/MockerToolWindowFactory.kt
@@ -136,7 +136,7 @@ class MockerToolWindowFactory : ToolWindowFactory {
 
         val tabs = JTabbedPane().apply {
             addTab("REST", restPanel)
-            addTab("Event Injection", wsPanel)
+            addTab("WebSocket", wsPanel)
         }
 
         val mainPanel = JPanel(BorderLayout()).apply {

--- a/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/WsPanel.kt
+++ b/plugin/src/main/kotlin/net/spooncast/openmocker/plugin/ui/WsPanel.kt
@@ -54,7 +54,7 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
     private val injectButton = JButton("보내기").apply { isEnabled = false }
     private val statusLabel = JBLabel("")
     private val refreshButton = JButton("새로고침")
-    private val clearRecordedButton = JButton("수신 Clear").apply { isEnabled = false }
+    private val clearRecordedButton = JButton("전체 Clear").apply { isEnabled = false }
 
     private var scheduler: ScheduledExecutorService? = null
 
@@ -135,7 +135,7 @@ class WsPanel(private val client: ControlClient) : JPanel(BorderLayout()) {
                 val result = client.clearRecorded(id)
                 SwingUtilities.invokeLater {
                     statusLabel.text = if (result.isSuccess) "● 수신 목록 비움"
-                    else "✗ 수신 Clear 실패: ${result.exceptionOrNull()?.message}"
+                    else "✗ 전체 Clear 실패: ${result.exceptionOrNull()?.message}"
                 }
                 if (result.isSuccess) refreshRecorded()
             }.apply { isDaemon = true; start() }


### PR DESCRIPTION
## Meta

PR Type: refactoring

Closes #164

## 문제/신규 기능 설명

WebSocket 관련 탭의 UI 문구를 기능·동작에 맞게 통일한다.

| 위치 | AS-IS | TO-BE |
| --- | --- | --- |
| 탭 이름 | Event Injection | WebSocket |
| 수신 이력 비우기 버튼 | 수신 Clear | 전체 Clear |
| 실패 상태 메시지 | ✗ 수신 Clear 실패 | ✗ 전체 Clear 실패 |
| `EventRecordedTableModel` 주석 | Event Injection 탭 | WebSocket 탭 |

## 적용 버전

해당 없음 (UI 문구만 변경, 라이브러리 동작 무관)

## 원인

신규 기능 — 해당 없음

## 수정/구현

- **탭 이름** — `MockerToolWindowFactory` 에서 `Event Injection` → `WebSocket` 으로 변경해 탭이 실제 기능(WebSocket 메시지 주입/수신)을 직관적으로 드러내도록 함.
- **버튼/메시지** — `WsPanel` 의 수신 이력 비우기 버튼과 실패 메시지를 `수신 Clear` → `전체 Clear` 로 변경. 실제 동작(대상의 전체 수신 이력 삭제) 및 REST 탭의 "전체 Clear" 표현과 일치.
- **주석** — `EventRecordedTableModel` 의 탭 지칭 표현을 함께 통일.
